### PR TITLE
ajuste erro hospital Jesus

### DIFF
--- a/models/raw/prontuario_vitai/_prontuario_vitai__schema.yml
+++ b/models/raw/prontuario_vitai/_prontuario_vitai__schema.yml
@@ -91,6 +91,7 @@ models:
               filter: prontuario_estoque_tem_dado = 'sim'
               config:
                 where: data_particao = date_sub(current_date(), INTERVAL 1 DAY)
+                error_if: ">1"
       - name: id_material
         description: Código de identificação do material cadastrado no prontuário
         policy_tags:


### PR DESCRIPTION
configurado para apresentar erro apenas acima de 1 , afim de evitar falso erro ate a completa implementação do hospital Jesus.