### PR TITLE
[HCI] Padronizações Gerais no Cadastro do Paciente

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -79,40 +79,35 @@ models:
         +labels:
           dado_publico: sim
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       cnes_ftp:
         +schema: brutos_cnes_ftp
         +tags: "weekly"
         +labels:
           dado_publico: sim
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       datasus:
         +schema: brutos_datasus
         +tags: "weekly"
         +labels:
           dado_publico: sim
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       monitoramento:
         +schema: gerenciamento__historico_clinico__logs
         +tags: "daily"
         +labels:
           dado_publico: nao
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       estoque_central_tpc:
         +schema: brutos_estoque_central_tpc
         +tags: "daily"
         +labels:
           dado_publico: nao
           dado_pessoal: nao
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
           dominio: estoque
       historico_clinico_integrado:
         +schema: brutos_historico_clinico_integrado
@@ -120,8 +115,7 @@ models:
         +labels:
           dado_publico: nao
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: sim
+          dado_sensivel: sim
           dominio: historico_clinico
       plataforma_smsrio:
         +schema: brutos_plataforma_smsrio
@@ -129,16 +123,14 @@ models:
         +labels:
           dado_publico: nao
           dado_pessoal: nao
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       prontuario_vitacare:
         +schema: brutos_prontuario_vitacare
         +tags: ["vitacare", "daily"]
         +labels:
           dado_publico: nao
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: sim
+          dado_sensivel: sim
           dominio: historico_clinico
       prontuario_vitai:
         +schema: brutos_prontuario_vitai
@@ -146,8 +138,7 @@ models:
         +labels:
           dado_publico: nao
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: sim
+          dado_sensivel: sim
           dominio: historico_clinico
       osinfo:
         +schema: brutos_osinfo
@@ -155,32 +146,28 @@ models:
         +labels:
           dado_publico: nao
           dado_pessoal: nao
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       seguir_em_frente:
         +schema: brutos_seguir_em_frente
         +tags: "daily"
         +labels:
           dado_publico: nao
           dado_pessoal: sim
-          dado_anonimizado: nao
-          dado_sensivel_saude: sim
+          dado_sensivel: sim
       sheets:
         +schema: brutos_sheets
         +tags: "daily"
         +labels:
           dado_publico: nao
           dado_pessoal: nao
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
       sih:
         +schema: brutos_sih
         +tags: "daily"
         +labels:
           dado_publico: nao
           dado_pessoal: nao
-          dado_anonimizado: nao
-          dado_sensivel_saude: nao
+          dado_sensivel: nao
     intermediate:
         +materialized: ephemeral
         historico_clinico:
@@ -188,8 +175,7 @@ models:
           +labels:
             dado_publico: nao
             dado_pessoal: sim
-            dado_anonimizado: nao
-            dado_sensivel_saude: sim
+            dado_sensivel: sim
             dominio: historico_clinico
           paciente:
             +tags: ["paciente"]
@@ -202,8 +188,7 @@ models:
             +labels:
               dado_publico: nao
               dado_pessoal: nao
-              dado_anonimizado: nao
-              dado_sensivel_saude: nao
+              dado_sensivel: nao
           facts:
             sisreg:
               +schema: saude_sisreg
@@ -211,16 +196,14 @@ models:
               +labels:
                 dado_publico: nao
                 dado_pessoal: nao
-                dado_anonimizado: nao
-                dado_sensivel_saude: nao
+                dado_sensivel: nao
             estoque:
               +schema: saude_estoque
               +tags: "daily"
               +labels:
                 dado_publico: nao
                 dado_pessoal: sim
-                dado_anonimizado: nao
-                dado_sensivel_saude: sim
+                dado_sensivel: sim
                 dominio: estoque
         dengue:
             +schema: projeto_dengue
@@ -231,8 +214,7 @@ models:
             +labels:
               dado_publico: nao
               dado_pessoal: sim
-              dado_anonimizado: nao
-              dado_sensivel_saude: sim
+              dado_sensivel: sim
               dominio: estoque
         gerenciamento:
             +tags: "daily"
@@ -241,16 +223,14 @@ models:
             +labels:
               dado_publico: nao
               dado_pessoal: sim
-              dado_anonimizado: nao
-              dado_sensivel_saude: sim
+              dado_sensivel: sim
               dominio: historico_clinico
         historico_clinico_app:
             +tags: ["daily", "hci_app"]
             +labels:
               dado_publico: nao
               dado_pessoal: sim
-              dado_anonimizado: nao
-              dado_sensivel_saude: sim
+              dado_sensivel: sim
               dominio: historico_clinico
         seguir_em_frente:
             +schema: projeto_seguir_em_frente
@@ -258,9 +238,8 @@ models:
             +labels:
               dado_publico: nao
               dado_pessoal: sim
-              dado_anonimizado: nao
-              dado_sensivel_saude: sim
-              dominio: seguir_em_frente
+              dado_sensivel: sim
+              dominio: seguir_em_frente 
 
 tests:
   rj_sms:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -273,6 +273,6 @@ seeds:
     estoque:
       +schema: projeto_estoque
 
-flags:
-  require_explicit_package_overrides_for_builtin_materializations: False
-  source_freshness_run_project_hooks: True
+# flags:
+#   require_explicit_package_overrides_for_builtin_materializations: False
+#   source_freshness_run_project_hooks: True

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -273,6 +273,6 @@ seeds:
     estoque:
       +schema: projeto_estoque
 
-# flags:
-#   require_explicit_package_overrides_for_builtin_materializations: False
-#   source_freshness_run_project_hooks: True
+flags:
+  require_explicit_package_overrides_for_builtin_materializations: False
+  source_freshness_run_project_hooks: True

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
@@ -11,7 +11,7 @@
 -- The goal is to consolidate information such as registration data,
 -- contact, address and medical record into a single view.
 -- Declaration of the variable to filter by CPF (optional)
-DECLARE cpf_filter STRING DEFAULT "53194179772";
+-- DECLARE cpf_filter STRING DEFAULT "";
 -- smsrio: Patient base table
 with
     smsrio_tb as (
@@ -42,7 +42,7 @@ with
             updated_at,
             cast(null as string) as id_cnes
         from {{ ref("raw_plataforma_smsrio__paciente") }}  -- `rj-sms-dev`.`brutos_plataforma_smsrio`.`paciente`
-        where {{ validate_cpf("cpf") }} and cpf = cpf_filter
+        where {{ validate_cpf("cpf") }}
     ),
 
     all_cpfs as (select distinct cpf from smsrio_tb),

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
@@ -91,29 +91,16 @@ with
         where dedup_rank = 1
         order by merge_order asc, rank asc
     ),
-    cns_validated AS (
-        SELECT
-            cns,
-            {{validate_cns('cns')}} AS cns_valido_indicador,
-        FROM (
-            SELECT DISTINCT cns FROM cns_dedup
-        )
+    cns_validated as (
+        select cns, {{ validate_cns("cns") }} as cns_valido_indicador,
+        from (select distinct cns from cns_dedup)
     ),
 
-    cns_dados AS (
-        SELECT 
-            cpf,
-            ARRAY_AGG(
-                    STRUCT(
-                        cd.cns, 
-                        cv.cns_valido_indicador,
-                        cd.rank
-                    )
-            ) AS cns
-        FROM cns_dedup cd
-        JOIN cns_validated cv
-            ON cd.cns = cv.cns
-        GROUP BY cpf
+    cns_dados as (
+        select cpf, array_agg(struct(cd.cns, cv.cns_valido_indicador, cd.rank)) as cns
+        from cns_dedup cd
+        join cns_validated cv on cd.cns = cv.cns
+        group by cpf
     ),
 
     -- CONTATO TELEPHONE
@@ -270,7 +257,7 @@ with
                 from
                     (
                         select cpf, valor, rank, "smsrio" as sistema, 2 as merge_order
-                        from smsrio_contato_telefone
+                        from smsrio_contato_email
                     )
                 order by merge_order asc, rank asc
             )

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
@@ -45,6 +45,8 @@ with
         where {{ validate_cpf("cpf") }}
     ),
 
+    all_cpfs as (select distinct cpf from smsrio_tb),
+
     -- CNS
     smsrio_cns_ranked as (
         select
@@ -272,7 +274,7 @@ with
 
     contato_dados as (
         select
-            coalesce(t.cpf, e.cpf) as cpf,
+            a.cpf as cpf,
             struct(
                 array_agg(
                     struct(
@@ -288,9 +290,10 @@ with
                     struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
                 ) as email
             ) as contato
-        from telefone_dedup t
-        full outer join email_dedup e on t.cpf = e.cpf
-        group by coalesce(t.cpf, e.cpf)
+        from all_cpfs a
+        left join telefone_dedup t on a.cpf = t.cpf
+        left join email_dedup e on a.cpf = e.cpf
+        group by a.cpf
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__smsrio.sql
@@ -272,28 +272,42 @@ with
         order by merge_order asc, rank asc
     ),
 
+    contato_telefone_dados as (
+        select
+            t.cpf,
+            array_agg(
+                struct(
+                    t.valor_original,
+                    t.ddd,
+                    t.valor,
+                    t.valor_tipo,
+                    lower(t.sistema) as sistema,
+                    t.rank
+                )
+            ) as telefone,
+        from telefone_dedup t
+        group by t.cpf
+    ),
+
+    contato_email_dados as (
+        select
+            e.cpf,
+            array_agg(
+                struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
+            ) as email
+        from email_dedup e
+        group by e.cpf
+    ),
+
     contato_dados as (
         select
-            a.cpf as cpf,
+            a.cpf,
             struct(
-                array_agg(
-                    struct(
-                        t.valor_original,
-                        t.ddd,
-                        t.valor,
-                        t.valor_tipo,
-                        lower(t.sistema) as sistema,
-                        t.rank
-                    )
-                ) as telefone,
-                array_agg(
-                    struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
-                ) as email
+                contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        left join telefone_dedup t on a.cpf = t.cpf
-        left join email_dedup e on a.cpf = e.cpf
-        group by a.cpf
+        inner join contato_email_dados using (cpf)
+        inner join contato_telefone_dados using (cpf)
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -104,30 +104,17 @@ with
         order by merge_order asc, rank asc
     ),
 
-cns_validated as (
-    select
-        cns,
-        {{validate_cns('cns')}} as cns_valido_indicador,
-    from (
-        select distinct cns from cns_dedup
-    )
-),
+    cns_validated as (
+        select cns, {{ validate_cns("cns") }} as cns_valido_indicador,
+        from (select distinct cns from cns_dedup)
+    ),
 
-cns_dados as (
-    select 
-        cpf,
-        array_agg(
-                struct(
-                    cd.cns, 
-                    cv.cns_valido_indicador,
-                    cd.rank
-                )
-        ) as cns
-    from cns_dedup cd
-    join cns_validated cv
-        on cd.cns = cv.cns
-    group by cpf
-),
+    cns_dados as (
+        select cpf, array_agg(struct(cd.cns, cv.cns_valido_indicador, cd.rank)) as cns
+        from cns_dedup cd
+        join cns_validated cv on cd.cns = cv.cns
+        group by cpf
+    ),
 
     -- EQUIPE SAUDE FAMILIA vitacare: Extracts and ranks family health teams
     -- clinica da familia

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -48,6 +48,8 @@ with
         where equipe_familia_indicador = true
     ),
 
+    all_cpfs as (select distinct cpf from paciente),
+
     -- CNS
     cns_ranked as (
         select
@@ -398,7 +400,7 @@ with
 
     contato_dados as (
         select
-            coalesce(t.cpf, e.cpf) as cpf,
+            a.cpf as cpf,
             struct(
                 array_agg(
                     struct(
@@ -414,9 +416,10 @@ with
                     struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
                 ) as email
             ) as contato
-        from telefone_dedup t
-        full outer join email_dedup e on t.cpf = e.cpf
-        group by coalesce(t.cpf, e.cpf)
+        from all_cpfs a
+        left join telefone_dedup t on a.cpf = t.cpf
+        left join email_dedup e on a.cpf = e.cpf
+        group by a.cpf
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -198,6 +198,7 @@ with
         select
             f.cpf,
             f.id_ine,
+            f.id_cnes,
             {{ proper_br("e.nome_referencia") }} as nome,
             e.telefone,
             m.medicos,
@@ -231,7 +232,7 @@ with
                 )
             ) as equipe_saude_familia
         from equipe_saude_familia_enriquecida ef
-        left join dim_clinica_familia cf on ef.cpf = cf.cpf
+        left join dim_clinica_familia cf on ef.cpf = cf.cpf and ef.id_cnes = cf.id_cnes
         group by cpf
     ),
 

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -413,6 +413,7 @@ with
                 )
             ) as telefone,
         from telefone_dedup t
+        where t.valor is not null
         group by t.cpf
     ),
 
@@ -423,6 +424,7 @@ with
                 struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
             ) as email
         from email_dedup e
+        where e.valor is not null
         group by e.cpf
     ),
 
@@ -433,8 +435,8 @@ with
                 contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        inner join contato_email_dados using (cpf)
-        inner join contato_telefone_dados using (cpf)
+        left join contato_email_dados using (cpf)
+        left join contato_telefone_dados using (cpf)
     ),
 
     -- ENDEREÇO
@@ -447,7 +449,11 @@ with
             numero,
             complemento,
             bairro,
-            cidade,
+            case
+                when regexp_contains(cidade, r'\d')
+                then trim(regexp_replace(cidade, r'\[.*', ''))
+                else cidade
+            end as cidade,
             estado,
             cast(
                 data_atualizacao_vinculo_equipe as string

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -398,28 +398,42 @@ with
         order by merge_order asc, rank asc
     ),
 
+    contato_telefone_dados as (
+        select
+            t.cpf,
+            array_agg(
+                struct(
+                    t.valor_original,
+                    t.ddd,
+                    t.valor,
+                    t.valor_tipo,
+                    lower(t.sistema) as sistema,
+                    t.rank
+                )
+            ) as telefone,
+        from telefone_dedup t
+        group by t.cpf
+    ),
+
+    contato_email_dados as (
+        select
+            e.cpf,
+            array_agg(
+                struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
+            ) as email
+        from email_dedup e
+        group by e.cpf
+    ),
+
     contato_dados as (
         select
-            a.cpf as cpf,
+            a.cpf,
             struct(
-                array_agg(
-                    struct(
-                        t.valor_original,
-                        t.ddd,
-                        t.valor,
-                        t.valor_tipo,
-                        lower(t.sistema) as sistema,
-                        t.rank
-                    )
-                ) as telefone,
-                array_agg(
-                    struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
-                ) as email
+                contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        left join telefone_dedup t on a.cpf = t.cpf
-        left join email_dedup e on a.cpf = e.cpf
-        group by a.cpf
+        inner join contato_email_dados using (cpf)
+        inner join contato_telefone_dados using (cpf)
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
@@ -90,28 +90,15 @@ with
         where dedup_rank = 1
         order by merge_order asc, rank asc
     ),
-    cns_validated AS (
-        SELECT
-            cns,
-            {{validate_cns('cns')}} AS cns_valido_indicador,
-        FROM (
-            SELECT DISTINCT cns FROM cns_dedup
-        )
+    cns_validated as (
+        select cns, {{ validate_cns("cns") }} as cns_valido_indicador,
+        from (select distinct cns from cns_dedup)
     ),
-    cns_dados AS (
-        SELECT 
-            cpf,
-            ARRAY_AGG(
-                    STRUCT(
-                        cd.cns, 
-                        cv.cns_valido_indicador,
-                        cd.rank
-                    )
-            ) AS cns
-        FROM cns_dedup cd
-        JOIN cns_validated cv
-            ON cd.cns = cv.cns
-        GROUP BY cpf
+    cns_dados as (
+        select cpf, array_agg(struct(cd.cns, cv.cns_valido_indicador, cd.rank)) as cns
+        from cns_dedup cd
+        join cns_validated cv on cd.cns = cv.cns
+        group by cpf
     ),
     -- CONTATO TELEPHONE
     vitai_contato_telefone as (

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
@@ -261,6 +261,7 @@ with
                 )
             ) as telefone,
         from telefone_dedup t
+        where t.valor is not null
         group by t.cpf
     ),
 
@@ -271,6 +272,7 @@ with
                 struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
             ) as email
         from email_dedup e
+        where e.valor is not null
         group by e.cpf
     ),
 
@@ -281,8 +283,8 @@ with
                 contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        inner join contato_email_dados using (cpf)
-        inner join contato_telefone_dados using (cpf)
+        left join contato_email_dados using (cpf)
+        left join contato_telefone_dados using (cpf)
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
@@ -247,28 +247,42 @@ with
         order by merge_order asc, rank asc
     ),
 
+    contato_telefone_dados as (
+        select
+            t.cpf,
+            array_agg(
+                struct(
+                    t.valor_original,
+                    t.ddd,
+                    t.valor,
+                    t.valor_tipo,
+                    lower(t.sistema) as sistema,
+                    t.rank
+                )
+            ) as telefone,
+        from telefone_dedup t
+        group by t.cpf
+    ),
+
+    contato_email_dados as (
+        select
+            e.cpf,
+            array_agg(
+                struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
+            ) as email
+        from email_dedup e
+        group by e.cpf
+    ),
+
     contato_dados as (
         select
-            a.cpf as cpf,
+            a.cpf,
             struct(
-                array_agg(
-                    struct(
-                        t.valor_original,
-                        t.ddd,
-                        t.valor,
-                        t.valor_tipo,
-                        lower(t.sistema) as sistema,
-                        t.rank
-                    )
-                ) as telefone,
-                array_agg(
-                    struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
-                ) as email
+                contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        left join telefone_dedup t on a.cpf = t.cpf
-        left join email_dedup e on a.cpf = e.cpf
-        group by a.cpf
+        inner join contato_email_dados using (cpf)
+        inner join contato_telefone_dados using (cpf)
     ),
 
     -- ENDEREÇO

--- a/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
+++ b/models/intermediate/historico_clinico/paciente/int_historico_clinico__paciente__vitai.sql
@@ -48,6 +48,8 @@ with
         where {{ validate_cpf("cpf") }}
     ),
 
+    all_cpfs as (select distinct cpf from vitai_tb),
+
     -- CNS
     vitai_cns_ranked as (
         select
@@ -247,7 +249,7 @@ with
 
     contato_dados as (
         select
-            coalesce(t.cpf, e.cpf) as cpf,
+            a.cpf as cpf,
             struct(
                 array_agg(
                     struct(
@@ -263,9 +265,10 @@ with
                     struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
                 ) as email
             ) as contato
-        from telefone_dedup t
-        full outer join email_dedup e on t.cpf = e.cpf
-        group by coalesce(t.cpf, e.cpf)
+        from all_cpfs a
+        left join telefone_dedup t on a.cpf = t.cpf
+        left join email_dedup e on a.cpf = e.cpf
+        group by a.cpf
     ),
 
     -- ENDEREÇO

--- a/models/marts/core/dimensions/_dimensions_schema.yml
+++ b/models/marts/core/dimensions/_dimensions_schema.yml
@@ -527,7 +527,7 @@ models:
       - name: outros_profissionais
         description: Código SUS dos outros profissionais atribuidos a equipe
   - name: dim_condicao_cid10
-    description: Tabela contendo a Classificação Internacional de Doenças (CID-10). Contém CID S44.6 e S44.5 com mesmas entradas pois S44.6 foi alterado para S44.5 em 2002.
+    description: Tabela contendo a Classificação Internacional de Doenças (CID-10).
     columns:
       - name: id
         description: Identificação da subcategoria do CID.
@@ -571,5 +571,3 @@ models:
       - name: grupo.comprimento
         description: Quantidade de caracteres do nome do grupo.
         data_type: int64
-      
-

--- a/models/marts/core/dimensions/dim_estabelecimento.sql
+++ b/models/marts/core/dimensions/dim_estabelecimento.sql
@@ -1,138 +1,87 @@
-{{ config(materialized="table", alias="estabelecimento", tags=["daily"]) }}
+{{ config(materialized='table', alias='estabelecimento', tags=['daily']) }}
 
+with source as (
+  select * from {{ ref('dim_estabelecimento_sus_rio_historico') }}
+),
 
-with
-    versao_atual as (
-        select max(data_particao) as versao from {{ ref("raw_cnes_web__tipo_unidade") }}
-    ),
+current_year as (
+  select max(ano_competencia) as ano_atual from source
+),
 
-    estabelecimento as (
-        select *
-        from {{ ref("raw_cnes_web__estabelecimento") }}
-        where data_particao = (select versao from versao_atual)
-    ),
+current_period as (
+  select 
+    cast(current_year.ano_atual as int64) as ano_atual,
+    cast(max(mes_competencia) as int64) as competencia_atual
+  from source
+  join current_year on source.ano_competencia = current_year.ano_atual
+  group by current_year.ano_atual
+),
 
-    unidade as (
-        select *
-        from {{ ref("raw_cnes_web__tipo_unidade") }}
-        where data_particao = (select versao from versao_atual)
-    ),
+final as (
+  select
+      -- primary key
+      id_unidade,
 
-    turno as (
-        select *
-        from {{ ref("raw_cnes_web__turno_atendimento") }}
-        where data_particao = (select versao from versao_atual)
-    ),
+      -- foreign keys
+      id_cnes,
+      safe_cast(id_tipo_unidade as string) as id_tipo_unidade,
+      safe_cast(id_ap as string) as area_programatica,
+      cnpj_mantenedora,
 
-    estab_sms as (
-        select *
-        from estabelecimento
-        where
-            cnpj_mantenedora = "29468055000102"  -- SMS-RIO
-            or id_cnes = "5456932"  -- Fio Cruz
-            or (id_municipio_gestor = "330455" and id_natureza_juridica = "2011")  -- Rio de Janeiro & Empresa Publica (Rio Saúde)
-            or (id_municipio_gestor = "330455" and id_natureza_juridica = "1031")  -- Rio de Janeiro & Orgao Publico do Poder Executivo Municipal
-    ),
+      -- common fields
+      ativa,
+      tipo_sms_agrupado,
+      tipo, -- trocar para tipo_cnes?
+      tipo_sms,
+      tipo_sms_simplificado,
+      nome_limpo,
+      nome_sigla,
+      nome_complemento,
+      nome_fantasia,
+      responsavel_sms,
+      administracao,
+      prontuario_tem,
+      prontuario_versao,
+      prontuario_estoque_tem_dado,
+      prontuario_estoque_motivo_sem_dado,
+      endereco_bairro,
+      endereco_logradouro,
+      endereco_numero,
+      endereco_complemento,
+      endereco_cep,
+      endereco_latitude,
+      endereco_longitude,
+      telefone,
+      email,
+      facebook,
+      instagram,
+      twitter,
+      aberto_sempre,
+      turno_atendimento,
+      diretor_clinico_cpf,
+      diretor_clinico_conselho,
 
-    estab_aux as (select * from {{ ref("raw_sheets__estabelecimento_auxiliar") }}),
+      -- metadata
+      data_atualizao_registro,
+      usuario_atualizador_registro,
+      safe_cast(mes_particao as string) as mes_particao,
+      safe_cast(ano_particao as string) as ano_particao,
+      data_particao,
+      data_carga,
+      data_snapshot
 
-    contatos_aps as (
-        select * from {{ ref("raw_plataforma_smsrio__estabelecimento_contato") }}
-    ),
+  from
+      source
+      join current_period on source.ano_competencia = current_period.ano_atual and source.mes_competencia = current_period.competencia_atual
+  where
+      estabelecimento_sms_indicador = 1
 
-    estab_final as (
-        select
-            estab_sms.*,
-            split(estab_sms.telefone, "/") as telefone_cnes,
-            contatos_aps.telefone as telefone_aps,
-            estab_sms.email as email_cnes,
-            contatos_aps.email as email_aps,
-            contatos_aps.facebook,
-            contatos_aps.instagram,
-            contatos_aps.twitter,
-            estab_aux.agrupador_sms,
-            estab_aux.tipo_sms,
-            estab_aux.tipo_sms_simplificado,
-            estab_aux.nome_limpo,
-            regexp_replace(
-                estab_aux.nome_limpo,
-                r'(CF |CSE |CMS |UPA 24h |POLICLINICA |HOSPITAL MUNICIPAL |COORD DE EMERGENCIA REGIONAL CER |MATERNIDADE )',
-                ''
-            ) as nome_complemento,
-            estab_aux.nome_sigla,
-            estab_aux.prontuario_tem,
-            estab_aux.prontuario_versao,
-            estab_aux.responsavel_sms,
-            estab_aux.administracao,
-            estab_aux.prontuario_estoque_tem_dado,
-            estab_aux.prontuario_estoque_motivo_sem_dado,
-            coalesce(
-                estab_aux.area_programatica, estab_sms.id_distrito_sanitario
-            ) as id_distrito_sanitario_corrigido,  -- corrige registros que possuem algum erro no cadsus
-        from estab_sms
-        left join estab_aux using (id_cnes)
-        left join contatos_aps using (id_cnes)
-    )
+  order by
+      ativa desc,
+      id_tipo_unidade asc,
+      area_programatica asc,
+      endereco_bairro asc,
+      nome_fantasia asc
+)
 
-select
-    -- Primary key
-    est.id_unidade,
-
-    -- Foreign keys
-    est.id_cnes,
-    est.id_tipo_unidade,
-    est.id_distrito_sanitario_corrigido as area_programatica,
-    est.cnpj_mantenedora,
-
-    -- Common fields
-    if(est.id_motivo_desativacao = "", "sim", "não") as ativa,
-    est.agrupador_sms as tipo_sms_agrupado,
-    unidade.descricao as tipo,  # TODO: renomear para tipo_cnes
-    est.tipo_sms,
-    est.tipo_sms_simplificado,
-    est.nome_limpo,
-    est.nome_sigla,
-    est.nome_complemento,
-    est.nome_fantasia,
-    est.responsavel_sms,
-    est.administracao,
-    est.prontuario_tem,
-    est.prontuario_versao,
-    est.prontuario_estoque_tem_dado,
-    est.prontuario_estoque_motivo_sem_dado,
-    est.endereco_bairro,
-    est.endereco_logradouro,
-    est.endereco_numero,
-    est.endereco_complemento,
-    est.endereco_cep,
-    est.endereco_latitude,
-    est.endereco_longitude,
-    coalesce(est.telefone_aps, est.telefone_cnes) as telefone,
-    coalesce(est.email_aps, est.email_cnes) as email,
-    est.facebook,
-    est.instagram,
-    est.twitter,
-    est.aberto_sempre,
-    turno.descricao as turno_atendimento,
-    est.diretor_clinico_cpf,
-    est.diretor_clinico_conselho,
-
-    -- Metadata
-    data_atualizao_registro,
-    usuario_atualizador_registro,
-    est.mes_particao,
-    est.ano_particao,
-    est.data_particao,
-    est.data_carga,
-    est.data_snapshot,
-
-from estab_final as est
-left join turno using (id_turno_atendimento)
-left join unidade using (id_tipo_unidade)
-
-order by
-    ativa desc,
-    est.id_tipo_unidade asc,
-    area_programatica asc,
-    est.endereco_bairro asc,
-    est.nome_fantasia asc
+select * from final

--- a/models/marts/core/dimensions/rio/_dimensions_rio_schema.yml
+++ b/models/marts/core/dimensions/rio/_dimensions_rio_schema.yml
@@ -1,0 +1,879 @@
+version: 2
+models:
+  - name: dim_estabelecimento_sus_rio_historico
+    description: Esta tabela contém dados sobre todos os estabelecimentos de saúde do Município do Rio de Janeiro que possuem algum tipo de vínculo com o SUS.
+
+    columns:
+      # Identificação
+      - name: ano_competencia
+        description: "Ano de referência dos dados."
+      - name: mes_competencia
+        description: "Mês de referência dos dados."
+      - name: id_cnes
+        description: "Código Nacional de Estabelecimento de Saúde (CNES) do estabelecimento."
+      - name: id_unidade
+        description: "Identificador específico do estabelecimento de saúde"
+      - name: nome_razao_social
+        description: "Razão social do estabelecimento conforme registro oficial."
+      - name: nome_fantasia
+        description: "Nome fantasia do estabelecimento."
+      - name: nome_limpo
+        description: "Nome do estabelecimento formatado."
+      - name: nome_sigla
+        description: "Sigla do nome do estabelecimento."
+      - name: nome_complemento
+        description: "Detalhes adicionais que complementam o nome principal do estabelecimento."
+      - name: cnpj_mantenedora
+        description: "CNPJ da entidade mantenedora do estabelecimento, importante para identificação legal e financeira."
+
+      # Responsabilização
+      - name: esfera
+        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
+      - name: id_natureza_juridica
+        description: "Código da natureza jurídica do estabelecimento."
+      - name: natureza_juridica_descr
+        description: "Descrição da natureza jurídica do estabelecimento."
+      - name: tipo_gestao
+        description: "Código indicativo do tipo de gestão (e.g., municipal, estadual)."
+      - name: tipo_gestao_descr
+        description: "Descrição do tipo de gestão do estabelecimento."
+      - name: responsavel_sms
+        description: "Setor da SMS responsável pelo estabelecimento."
+      - name: administracao
+        description: "Administração do estabelecimento."
+      - name: diretor_clinico_cpf
+        description: "CPF do diretor clínico do estabelecimento."
+        policy_tags:
+          - '{{ var ("TAG_CPF") }}'
+      - name: diretor_clinico_conselho
+        description: "Número de registro no conselho profissional do diretor clínico."
+        policy_tags:
+          - '{{ var ("TAG_CRM") }}'
+
+      # Atributos
+      - name: tipo_turno
+        description: "Código indicativo do turno de atendimento (manhã, tarde, integral)."
+      - name: turno_atendimento
+        description: "Descrição do turno de atendimento."
+      - name: aberto_sempre
+        description: "Indica se o estabelecimento opera continuamente, 24 horas por dia."
+
+      # Tipagem dos Estabelecimentos (CNES)
+      - name: id_tipo_unidade
+        description: "Código do tipo de unidade de saúde."
+      - name: tipo
+        description: "Descrição do tipo de unidade de saúde."
+
+      # Tipagem dos Estabelecimentos (DIT)
+      - name: tipo_sms
+        description: "Categoria relacionada a serviços de saúde."
+      - name: tipo_sms_simplificado
+        description: "Versão simplificada da categoria de SMS, utilizada para classificação geral."
+      - name: tipo_sms_agrupado
+        description: "Variável de agrupamento relacionada a tipagem do estabelecimento."
+
+      # Tipagem dos Estabelecimentos (SUBGERAL)
+      - name: tipo_unidade_alternativo
+        description: "Classificação alternativa do tipo de unidade conforme categorização interna."
+      - name: tipo_unidade_agrupado
+        description: "Classificação agrupada do tipo de unidade de saúde."
+
+      # Localização
+      - name: id_ap
+        description: "Código da Área Programática."
+      - name: ap
+        description: "Descrição da Área Programática."
+      - name: endereco_cep
+        description: "CEP do estabelecimento."
+      - name: endereco_bairro
+        description: "Bairro onde o estabelecimento está localizado."
+      - name: endereco_logradouro
+        description: "Logradouro do endereço do estabelecimento."
+      - name: endereco_numero
+        description: "Número do endereço do estabelecimento."
+      - name: endereco_complemento
+        description: "Complemento do endereço do estabelecimento."
+      - name: endereco_latitude
+        description: "Latitude do estabelecimento para georreferenciamento."
+      - name: endereco_longitude
+        description: "Longitude do estabelecimento para georreferenciamento."
+
+      # Status
+      - name: ativa
+        description: "Indica o status operacional do estabelecimento ('sim' para ativo, 'não' para inativo)."
+
+      # Prontuário
+      - name: prontuario_tem
+        description: "Indica se o estabelecimento mantém prontuários dos pacientes."
+      - name: prontuario_versao
+        description: "Versão do prontuário utilizado pelo estabelecimento."
+      - name: prontuario_estoque_tem_dado
+        description: "Indica se os prontuários contêm dados disponíveis."
+      - name: prontuario_estoque_motivo_sem_dado
+        description: "Motivo pelo qual os prontuários não contêm dados."
+
+      # Informações de Contato
+      - name: telefone
+        description: "Número de telefone principal para contato com o estabelecimento."
+      - name: email
+        description: "Endereço de e-mail principal do estabelecimento."
+      - name: facebook
+        description: "Página do Facebook do estabelecimento."
+      - name: instagram
+        description: "Perfil do Instagram do estabelecimento."
+      - name: twitter
+        description: "Conta do Twitter do estabelecimento."
+
+      # Indicadores
+      - name: estabelecimento_sms_indicador
+        description: "Indica se o estabelecimento faz parte da rede municipal de saúde."
+      - name: vinculo_sus_indicador
+        description: "Indica se o estabelecimento possui vínculo com o SUS."
+      - name: atendimento_internacao_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de internação pelo SUS."
+      - name: atendimento_ambulatorial_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços ambulatoriais pelo SUS."
+      - name: atendimento_sadt_sus_indicador
+        description: "Indica se o estabelecimento oferece Serviços Auxiliares de Diagnóstico e Terapia (SADT) pelo SUS."
+      - name: atendimento_urgencia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de urgência pelo SUS."
+      - name: atendimento_outros_sus_indicador
+        description: "Indica se o estabelecimento oferece outros tipos de serviços pelo SUS."
+      - name: atendimento_vigilancia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de vigilância em saúde pelo SUS."
+      - name: atendimento_regulacao_sus_indicador
+        description: "Indica se o estabelecimento atua em atividades de regulação de serviços de saúde pelo SUS."
+
+      # Metadados
+      - name: data_atualizao_registro
+        description: "Data em que o registro foi atualizado pela última vez."
+      - name: usuario_atualizador_registro
+        description: "Identificador do usuário que atualizou o registro pela última vez."
+      - name: mes_particao
+        description: "Mês utilizado para fins de particionamento dos dados."
+      - name: ano_particao
+        description: "Ano utilizado para fins de particionamento dos dados."
+      - name: data_particao
+        description: "Data específica utilizada para particionamento dos dados."
+      - name: data_carga
+        description: "Data em que os dados foram carregados no banco de dados."
+      - name: data_snapshot
+        description: "Data em que o snapshot dos dados foi capturado."
+
+  - name: dim_leito_sus_rio_historico
+    description: Esta tabela contém dados sobre os leitos de todos os estabelecimentos de saúde do Município do Rio de Janeiro que possuem algum tipo de vínculo com o SUS.
+
+    columns:
+      # --------------------------------- ESTABELECIMENTOS
+      # Identificação
+      - name: ano_competencia
+        description: "Ano de referência dos dados."
+      - name: mes_competencia
+        description: "Mês de referência dos dados."
+      - name: id_cnes
+        description: "Código Nacional de Estabelecimento de Saúde (CNES) do estabelecimento."
+      - name: id_unidade
+        description: "Identificador específico do estabelecimento de saúde"
+      - name: nome_razao_social
+        description: "Razão social do estabelecimento conforme registro oficial."
+      - name: nome_fantasia
+        description: "Nome fantasia do estabelecimento."
+      - name: nome_limpo
+        description: "Nome do estabelecimento formatado."
+      - name: nome_sigla
+        description: "Sigla do nome do estabelecimento."
+      - name: nome_complemento
+        description: "Detalhes adicionais que complementam o nome principal do estabelecimento."
+      - name: cnpj_mantenedora
+        description: "CNPJ da entidade mantenedora do estabelecimento, importante para identificação legal e financeira."
+
+      # Responsabilização
+      - name: esfera
+        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
+      - name: id_natureza_juridica
+        description: "Código da natureza jurídica do estabelecimento."
+      - name: natureza_juridica_descr
+        description: "Descrição da natureza jurídica do estabelecimento."
+      - name: tipo_gestao
+        description: "Código indicativo do tipo de gestão (e.g., municipal, estadual)."
+      - name: tipo_gestao_descr
+        description: "Descrição do tipo de gestão do estabelecimento."
+      - name: responsavel_sms
+        description: "Setor da SMS responsável pelo estabelecimento."
+      - name: administracao
+        description: "Administração do estabelecimento."
+      - name: diretor_clinico_cpf
+        description: "CPF do diretor clínico do estabelecimento."
+      - name: diretor_clinico_conselho
+        description: "Número de registro no conselho profissional do diretor clínico."
+
+      # Atributos
+      - name: tipo_turno
+        description: "Código indicativo do turno de atendimento (manhã, tarde, integral)."
+      - name: turno_atendimento
+        description: "Descrição do turno de atendimento."
+      - name: aberto_sempre
+        description: "Indica se o estabelecimento opera continuamente, 24 horas por dia."
+
+      # Tipagem dos Estabelecimentos (CNES)
+      - name: id_tipo_unidade
+        description: "Código do tipo de unidade de saúde."
+      - name: tipo
+        description: "Descrição do tipo de unidade de saúde."
+
+      # Tipagem dos Estabelecimentos (DIT)
+      - name: tipo_sms
+        description: "Categoria relacionada a serviços de saúde."
+      - name: tipo_sms_simplificado
+        description: "Versão simplificada da categoria de SMS, utilizada para classificação geral."
+      - name: tipo_sms_agrupado
+        description: "Variável de agrupamento relacionada a tipagem do estabelecimento."
+
+      # Tipagem dos Estabelecimentos (SUBGERAL)
+      - name: tipo_unidade_alternativo
+        description: "Classificação alternativa do tipo de unidade conforme categorização interna."
+      - name: tipo_unidade_agrupado
+        description: "Classificação agrupada do tipo de unidade de saúde."
+
+      # Localização
+      - name: id_ap
+        description: "Código da Área Programática."
+      - name: ap
+        description: "Descrição da Área Programática."
+      - name: endereco_cep
+        description: "CEP do estabelecimento."
+      - name: endereco_bairro
+        description: "Bairro onde o estabelecimento está localizado."
+      - name: endereco_logradouro
+        description: "Logradouro do endereço do estabelecimento."
+      - name: endereco_numero
+        description: "Número do endereço do estabelecimento."
+      - name: endereco_complemento
+        description: "Complemento do endereço do estabelecimento."
+      - name: endereco_latitude
+        description: "Latitude do estabelecimento para georreferenciamento."
+      - name: endereco_longitude
+        description: "Longitude do estabelecimento para georreferenciamento."
+
+      # Status
+      - name: ativa
+        description: "Indica o status operacional do estabelecimento ('sim' para ativo, 'não' para inativo)."
+
+      # Prontuário
+      - name: prontuario_tem
+        description: "Indica se o estabelecimento mantém prontuários dos pacientes."
+      - name: prontuario_versao
+        description: "Versão do prontuário utilizado pelo estabelecimento."
+      - name: prontuario_estoque_tem_dado
+        description: "Indica se os prontuários contêm dados disponíveis."
+      - name: prontuario_estoque_motivo_sem_dado
+        description: "Motivo pelo qual os prontuários não contêm dados."
+
+      # Informações de Contato
+      - name: telefone
+        description: "Número de telefone principal para contato com o estabelecimento."
+      - name: email
+        description: "Endereço de e-mail principal do estabelecimento."
+      - name: facebook
+        description: "Página do Facebook do estabelecimento."
+      - name: instagram
+        description: "Perfil do Instagram do estabelecimento."
+      - name: twitter
+        description: "Conta do Twitter do estabelecimento."
+
+      # Indicadores
+      - name: estabelecimento_sms_indicador
+        description: "Indica se o estabelecimento faz parte da rede municipal de saúde."
+      - name: vinculo_sus_indicador
+        description: "Indica se o estabelecimento possui vínculo com o SUS."
+      - name: atendimento_internacao_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de internação pelo SUS."
+      - name: atendimento_ambulatorial_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços ambulatoriais pelo SUS."
+      - name: atendimento_sadt_sus_indicador
+        description: "Indica se o estabelecimento oferece Serviços Auxiliares de Diagnóstico e Terapia (SADT) pelo SUS."
+      - name: atendimento_urgencia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de urgência pelo SUS."
+      - name: atendimento_outros_sus_indicador
+        description: "Indica se o estabelecimento oferece outros tipos de serviços pelo SUS."
+      - name: atendimento_vigilancia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de vigilância em saúde pelo SUS."
+      - name: atendimento_regulacao_sus_indicador
+        description: "Indica se o estabelecimento atua em atividades de regulação de serviços de saúde pelo SUS."
+
+      # Metadados
+      - name: data_atualizao_registro
+        description: "Data em que o registro foi atualizado pela última vez."
+      - name: usuario_atualizador_registro
+        description: "Identificador do usuário que atualizou o registro pela última vez."
+      - name: mes_particao
+        description: "Mês utilizado para fins de particionamento dos dados."
+      - name: ano_particao
+        description: "Ano utilizado para fins de particionamento dos dados."
+      - name: data_particao
+        description: "Data específica utilizada para particionamento dos dados."
+      - name: data_carga
+        description: "Data em que os dados foram carregados no banco de dados."
+      - name: data_snapshot
+        description: "Data em que o snapshot dos dados foi capturado."
+
+      # --------------------------------- LEITOS
+      - name: tipo_leito
+        description: "Identificador do tipo de leito disponível."
+      - name: tipo_leito_descr
+        description: "Descrição do tipo de leito disponível."
+      - name: tipo_especialidade_leito
+        description: "Identificador da especialidade do leito."
+      - name: tipo_especialidade_leito_descr
+        description: "Descrição da especialidade do leito."
+      - name: quantidade_total
+        description: "Quantidade total de leitos disponíveis."
+      - name: quantidade_contratado
+        description: "Quantidade de leitos contratados."
+      - name: quantidade_sus
+        description: "Quantidade de leitos disponíveis pelo Sistema Único de Saúde (SUS)."
+    
+  - name: dim_habilitacao_sus_rio_historico
+    description: Esta tabela contém dados sobre as habilitações de todos os estabelecimentos de saúde do Município do Rio de Janeiro que possuem algum tipo de vínculo com o SUS.
+
+    columns:
+      # --------------------------------- ESTABELECIMENTOS
+      # Identificação
+      - name: ano_competencia
+        description: "Ano de referência dos dados."
+      - name: mes_competencia
+        description: "Mês de referência dos dados."
+      - name: id_cnes
+        description: "Código Nacional de Estabelecimento de Saúde (CNES) do estabelecimento."
+      - name: id_unidade
+        description: "Identificador específico do estabelecimento de saúde"
+      - name: nome_razao_social
+        description: "Razão social do estabelecimento conforme registro oficial."
+      - name: nome_fantasia
+        description: "Nome fantasia do estabelecimento."
+      - name: nome_limpo
+        description: "Nome do estabelecimento formatado."
+      - name: nome_sigla
+        description: "Sigla do nome do estabelecimento."
+      - name: nome_complemento
+        description: "Detalhes adicionais que complementam o nome principal do estabelecimento."
+      - name: cnpj_mantenedora
+        description: "CNPJ da entidade mantenedora do estabelecimento, importante para identificação legal e financeira."
+
+      # Responsabilização
+      - name: esfera
+        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
+      - name: id_natureza_juridica
+        description: "Código da natureza jurídica do estabelecimento."
+      - name: natureza_juridica_descr
+        description: "Descrição da natureza jurídica do estabelecimento."
+      - name: tipo_gestao
+        description: "Código indicativo do tipo de gestão (e.g., municipal, estadual)."
+      - name: tipo_gestao_descr
+        description: "Descrição do tipo de gestão do estabelecimento."
+      - name: responsavel_sms
+        description: "Setor da SMS responsável pelo estabelecimento."
+      - name: administracao
+        description: "Administração do estabelecimento."
+      - name: diretor_clinico_cpf
+        description: "CPF do diretor clínico do estabelecimento."
+      - name: diretor_clinico_conselho
+        description: "Número de registro no conselho profissional do diretor clínico."
+
+      # Atributos
+      - name: tipo_turno
+        description: "Código indicativo do turno de atendimento (manhã, tarde, integral)."
+      - name: turno_atendimento
+        description: "Descrição do turno de atendimento."
+      - name: aberto_sempre
+        description: "Indica se o estabelecimento opera continuamente, 24 horas por dia."
+
+      # Tipagem dos Estabelecimentos (CNES)
+      - name: id_tipo_unidade
+        description: "Código do tipo de unidade de saúde."
+      - name: tipo
+        description: "Descrição do tipo de unidade de saúde."
+
+      # Tipagem dos Estabelecimentos (DIT)
+      - name: tipo_sms
+        description: "Categoria relacionada a serviços de saúde."
+      - name: tipo_sms_simplificado
+        description: "Versão simplificada da categoria de SMS, utilizada para classificação geral."
+      - name: tipo_sms_agrupado
+        description: "Variável de agrupamento relacionada a tipagem do estabelecimento."
+
+      # Tipagem dos Estabelecimentos (SUBGERAL)
+      - name: tipo_unidade_alternativo
+        description: "Classificação alternativa do tipo de unidade conforme categorização interna."
+      - name: tipo_unidade_agrupado
+        description: "Classificação agrupada do tipo de unidade de saúde."
+
+      # Localização
+      - name: id_ap
+        description: "Código da Área Programática."
+      - name: ap
+        description: "Descrição da Área Programática."
+      - name: endereco_cep
+        description: "CEP do estabelecimento."
+      - name: endereco_bairro
+        description: "Bairro onde o estabelecimento está localizado."
+      - name: endereco_logradouro
+        description: "Logradouro do endereço do estabelecimento."
+      - name: endereco_numero
+        description: "Número do endereço do estabelecimento."
+      - name: endereco_complemento
+        description: "Complemento do endereço do estabelecimento."
+      - name: endereco_latitude
+        description: "Latitude do estabelecimento para georreferenciamento."
+      - name: endereco_longitude
+        description: "Longitude do estabelecimento para georreferenciamento."
+
+      # Status
+      - name: ativa
+        description: "Indica o status operacional do estabelecimento ('sim' para ativo, 'não' para inativo)."
+
+      # Prontuário
+      - name: prontuario_tem
+        description: "Indica se o estabelecimento mantém prontuários dos pacientes."
+      - name: prontuario_versao
+        description: "Versão do prontuário utilizado pelo estabelecimento."
+      - name: prontuario_estoque_tem_dado
+        description: "Indica se os prontuários contêm dados disponíveis."
+      - name: prontuario_estoque_motivo_sem_dado
+        description: "Motivo pelo qual os prontuários não contêm dados."
+
+      # Informações de Contato
+      - name: telefone
+        description: "Número de telefone principal para contato com o estabelecimento."
+      - name: email
+        description: "Endereço de e-mail principal do estabelecimento."
+      - name: facebook
+        description: "Página do Facebook do estabelecimento."
+      - name: instagram
+        description: "Perfil do Instagram do estabelecimento."
+      - name: twitter
+        description: "Conta do Twitter do estabelecimento."
+
+      # Indicadores
+      - name: estabelecimento_sms_indicador
+        description: "Indica se o estabelecimento faz parte da rede municipal de saúde."
+      - name: vinculo_sus_indicador
+        description: "Indica se o estabelecimento possui vínculo com o SUS."
+      - name: atendimento_internacao_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de internação pelo SUS."
+      - name: atendimento_ambulatorial_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços ambulatoriais pelo SUS."
+      - name: atendimento_sadt_sus_indicador
+        description: "Indica se o estabelecimento oferece Serviços Auxiliares de Diagnóstico e Terapia (SADT) pelo SUS."
+      - name: atendimento_urgencia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de urgência pelo SUS."
+      - name: atendimento_outros_sus_indicador
+        description: "Indica se o estabelecimento oferece outros tipos de serviços pelo SUS."
+      - name: atendimento_vigilancia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de vigilância em saúde pelo SUS."
+      - name: atendimento_regulacao_sus_indicador
+        description: "Indica se o estabelecimento atua em atividades de regulação de serviços de saúde pelo SUS."
+
+      # Metadados
+      - name: data_atualizao_registro
+        description: "Data em que o registro foi atualizado pela última vez."
+      - name: usuario_atualizador_registro
+        description: "Identificador do usuário que atualizou o registro pela última vez."
+      - name: mes_particao
+        description: "Mês utilizado para fins de particionamento dos dados."
+      - name: ano_particao
+        description: "Ano utilizado para fins de particionamento dos dados."
+      - name: data_particao
+        description: "Data específica utilizada para particionamento dos dados."
+      - name: data_carga
+        description: "Data em que os dados foram carregados no banco de dados."
+      - name: data_snapshot
+        description: "Data em que o snapshot dos dados foi capturado."
+
+      # --------------------------------- HABILITACOES
+      - name: id_habilitacao
+        description: "Identificador único da habilitação de um estabelecimento de saúde."
+      - name: nivel_habilitacao
+        description: "Nível de habilitação do estabelecimento de saúde."
+      - name: habilitacao_ativa_indicador
+        description: "Indicador se a habilitação está ativa (1) ou não (0)."
+      - name: habilitacao_ano_inicio
+        description: "Ano de início da habilitação."
+      - name: habilitacao_mes_inicio
+        description: "Mês de início da habilitação."
+      - name: habilitacao_ano_fim
+        description: "Ano de término da habilitação, se aplicável."
+      - name: habilitacao_mes_fim
+        description: "Mês de término da habilitação, se aplicável."
+      - name: habilitacao
+        description: "Descrição detalhada da habilitação."
+      - name: tipo_origem
+        description: "Tipo de origem da habilitação."
+      - name: tipo_habilitacao
+        description: "Tipo de habilitação."
+
+  - name: dim_equipamento_sus_rio_historico
+    description: Esta tabela contém dados sobre os equipamentos de todos os estabelecimentos de saúde do Município do Rio de Janeiro que possuem algum tipo de vínculo com o SUS.
+
+    columns:
+      # --------------------------------- ESTABELECIMENTOS
+      # Identificação
+      - name: ano_competencia
+        description: "Ano de referência dos dados."
+      - name: mes_competencia
+        description: "Mês de referência dos dados."
+      - name: id_cnes
+        description: "Código Nacional de Estabelecimento de Saúde (CNES) do estabelecimento."
+      - name: id_unidade
+        description: "Identificador específico do estabelecimento de saúde"
+      - name: nome_razao_social
+        description: "Razão social do estabelecimento conforme registro oficial."
+      - name: nome_fantasia
+        description: "Nome fantasia do estabelecimento."
+      - name: nome_limpo
+        description: "Nome do estabelecimento formatado."
+      - name: nome_sigla
+        description: "Sigla do nome do estabelecimento."
+      - name: nome_complemento
+        description: "Detalhes adicionais que complementam o nome principal do estabelecimento."
+      - name: cnpj_mantenedora
+        description: "CNPJ da entidade mantenedora do estabelecimento, importante para identificação legal e financeira."
+
+      # Responsabilização
+      - name: esfera
+        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
+      - name: id_natureza_juridica
+        description: "Código da natureza jurídica do estabelecimento."
+      - name: natureza_juridica_descr
+        description: "Descrição da natureza jurídica do estabelecimento."
+      - name: tipo_gestao
+        description: "Código indicativo do tipo de gestão (e.g., municipal, estadual)."
+      - name: tipo_gestao_descr
+        description: "Descrição do tipo de gestão do estabelecimento."
+      - name: responsavel_sms
+        description: "Setor da SMS responsável pelo estabelecimento."
+      - name: administracao
+        description: "Administração do estabelecimento."
+      - name: diretor_clinico_cpf
+        description: "CPF do diretor clínico do estabelecimento."
+      - name: diretor_clinico_conselho
+        description: "Número de registro no conselho profissional do diretor clínico."
+
+      # Atributos
+      - name: tipo_turno
+        description: "Código indicativo do turno de atendimento (manhã, tarde, integral)."
+      - name: turno_atendimento
+        description: "Descrição do turno de atendimento."
+      - name: aberto_sempre
+        description: "Indica se o estabelecimento opera continuamente, 24 horas por dia."
+
+      # Tipagem dos Estabelecimentos (CNES)
+      - name: id_tipo_unidade
+        description: "Código do tipo de unidade de saúde."
+      - name: tipo
+        description: "Descrição do tipo de unidade de saúde."
+
+      # Tipagem dos Estabelecimentos (DIT)
+      - name: tipo_sms
+        description: "Categoria relacionada a serviços de saúde."
+      - name: tipo_sms_simplificado
+        description: "Versão simplificada da categoria de SMS, utilizada para classificação geral."
+      - name: tipo_sms_agrupado
+        description: "Variável de agrupamento relacionada a tipagem do estabelecimento."
+
+      # Tipagem dos Estabelecimentos (SUBGERAL)
+      - name: tipo_unidade_alternativo
+        description: "Classificação alternativa do tipo de unidade conforme categorização interna."
+      - name: tipo_unidade_agrupado
+        description: "Classificação agrupada do tipo de unidade de saúde."
+
+      # Localização
+      - name: id_ap
+        description: "Código da Área Programática."
+      - name: ap
+        description: "Descrição da Área Programática."
+      - name: endereco_cep
+        description: "CEP do estabelecimento."
+      - name: endereco_bairro
+        description: "Bairro onde o estabelecimento está localizado."
+      - name: endereco_logradouro
+        description: "Logradouro do endereço do estabelecimento."
+      - name: endereco_numero
+        description: "Número do endereço do estabelecimento."
+      - name: endereco_complemento
+        description: "Complemento do endereço do estabelecimento."
+      - name: endereco_latitude
+        description: "Latitude do estabelecimento para georreferenciamento."
+      - name: endereco_longitude
+        description: "Longitude do estabelecimento para georreferenciamento."
+
+      # Status
+      - name: ativa
+        description: "Indica o status operacional do estabelecimento ('sim' para ativo, 'não' para inativo)."
+
+      # Prontuário
+      - name: prontuario_tem
+        description: "Indica se o estabelecimento mantém prontuários dos pacientes."
+      - name: prontuario_versao
+        description: "Versão do prontuário utilizado pelo estabelecimento."
+      - name: prontuario_estoque_tem_dado
+        description: "Indica se os prontuários contêm dados disponíveis."
+      - name: prontuario_estoque_motivo_sem_dado
+        description: "Motivo pelo qual os prontuários não contêm dados."
+
+      # Informações de Contato
+      - name: telefone
+        description: "Número de telefone principal para contato com o estabelecimento."
+      - name: email
+        description: "Endereço de e-mail principal do estabelecimento."
+      - name: facebook
+        description: "Página do Facebook do estabelecimento."
+      - name: instagram
+        description: "Perfil do Instagram do estabelecimento."
+      - name: twitter
+        description: "Conta do Twitter do estabelecimento."
+
+      # Indicadores
+      - name: estabelecimento_sms_indicador
+        description: "Indica se o estabelecimento faz parte da rede municipal de saúde."
+      - name: vinculo_sus_indicador
+        description: "Indica se o estabelecimento possui vínculo com o SUS."
+      - name: atendimento_internacao_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de internação pelo SUS."
+      - name: atendimento_ambulatorial_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços ambulatoriais pelo SUS."
+      - name: atendimento_sadt_sus_indicador
+        description: "Indica se o estabelecimento oferece Serviços Auxiliares de Diagnóstico e Terapia (SADT) pelo SUS."
+      - name: atendimento_urgencia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de urgência pelo SUS."
+      - name: atendimento_outros_sus_indicador
+        description: "Indica se o estabelecimento oferece outros tipos de serviços pelo SUS."
+      - name: atendimento_vigilancia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de vigilância em saúde pelo SUS."
+      - name: atendimento_regulacao_sus_indicador
+        description: "Indica se o estabelecimento atua em atividades de regulação de serviços de saúde pelo SUS."
+
+      # Metadados
+      - name: data_atualizao_registro
+        description: "Data em que o registro foi atualizado pela última vez."
+      - name: usuario_atualizador_registro
+        description: "Identificador do usuário que atualizou o registro pela última vez."
+      - name: mes_particao
+        description: "Mês utilizado para fins de particionamento dos dados."
+      - name: ano_particao
+        description: "Ano utilizado para fins de particionamento dos dados."
+      - name: data_particao
+        description: "Data específica utilizada para particionamento dos dados."
+      - name: data_carga
+        description: "Data em que os dados foram carregados no banco de dados."
+      - name: data_snapshot
+        description: "Data em que o snapshot dos dados foi capturado."
+
+      # --------------------------------- EQUIPAMENTOS
+      - name: equipamento_tipo
+        description: "Tipo geral do equipamento."
+      - name: equipamento_especifico_tipo
+        description: "Tipo específico do equipamento."
+      - name: equipamentos_quantidade
+        description: "Quantidade total de equipamentos do tipo especificado."
+      - name: equipamentos_quantidade_ativos
+        description: "Quantidade de equipamentos ativos do tipo especificado."
+      - name: equipamento
+        description: "Descrição geral do equipamento."
+      - name: equipamento_especifico
+        description: "Descrição específica do equipamento."
+
+  - name: dim_profissional_sus_rio_historico
+    description: Esta tabela contém dados sobre todos os profissionais de saúde do Município do Rio de Janeiro que possuem algum tipo de vínculo com o SUS.
+
+    columns:
+      # --------------------------------- ESTABELECIMENTOS
+      # Identificação
+      - name: ano_competencia
+        description: "Ano de referência dos dados."
+      - name: mes_competencia
+        description: "Mês de referência dos dados."
+      - name: id_cnes
+        description: "Código Nacional de Estabelecimento de Saúde (CNES) do estabelecimento."
+      - name: id_unidade
+        description: "Identificador específico do estabelecimento de saúde"
+      - name: nome_razao_social
+        description: "Razão social do estabelecimento conforme registro oficial."
+      - name: nome_fantasia
+        description: "Nome fantasia do estabelecimento."
+      - name: nome_limpo
+        description: "Nome do estabelecimento formatado."
+      - name: nome_sigla
+        description: "Sigla do nome do estabelecimento."
+      - name: nome_complemento
+        description: "Detalhes adicionais que complementam o nome principal do estabelecimento."
+      - name: cnpj_mantenedora
+        description: "CNPJ da entidade mantenedora do estabelecimento, importante para identificação legal e financeira."
+
+      # Responsabilização
+      - name: esfera
+        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
+      - name: id_natureza_juridica
+        description: "Código da natureza jurídica do estabelecimento."
+      - name: natureza_juridica_descr
+        description: "Descrição da natureza jurídica do estabelecimento."
+      - name: tipo_gestao
+        description: "Código indicativo do tipo de gestão (e.g., municipal, estadual)."
+      - name: tipo_gestao_descr
+        description: "Descrição do tipo de gestão do estabelecimento."
+      - name: responsavel_sms
+        description: "Setor da SMS responsável pelo estabelecimento."
+      - name: administracao
+        description: "Administração do estabelecimento."
+      - name: diretor_clinico_cpf
+        description: "CPF do diretor clínico do estabelecimento."
+      - name: diretor_clinico_conselho
+        description: "Número de registro no conselho profissional do diretor clínico."
+
+      # Atributos
+      - name: tipo_turno
+        description: "Código indicativo do turno de atendimento (manhã, tarde, integral)."
+      - name: turno_atendimento
+        description: "Descrição do turno de atendimento."
+      - name: aberto_sempre
+        description: "Indica se o estabelecimento opera continuamente, 24 horas por dia."
+
+      # Tipagem dos Estabelecimentos (CNES)
+      - name: id_tipo_unidade
+        description: "Código do tipo de unidade de saúde."
+      - name: tipo
+        description: "Descrição do tipo de unidade de saúde."
+
+      # Tipagem dos Estabelecimentos (DIT)
+      - name: tipo_sms
+        description: "Categoria relacionada a serviços de saúde."
+      - name: tipo_sms_simplificado
+        description: "Versão simplificada da categoria de SMS, utilizada para classificação geral."
+      - name: tipo_sms_agrupado
+        description: "Variável de agrupamento relacionada a tipagem do estabelecimento."
+
+      # Tipagem dos Estabelecimentos (SUBGERAL)
+      - name: tipo_unidade_alternativo
+        description: "Classificação alternativa do tipo de unidade conforme categorização interna."
+      - name: tipo_unidade_agrupado
+        description: "Classificação agrupada do tipo de unidade de saúde."
+
+      # Localização
+      - name: id_ap
+        description: "Código da Área Programática."
+      - name: ap
+        description: "Descrição da Área Programática."
+      - name: endereco_cep
+        description: "CEP do estabelecimento."
+      - name: endereco_bairro
+        description: "Bairro onde o estabelecimento está localizado."
+      - name: endereco_logradouro
+        description: "Logradouro do endereço do estabelecimento."
+      - name: endereco_numero
+        description: "Número do endereço do estabelecimento."
+      - name: endereco_complemento
+        description: "Complemento do endereço do estabelecimento."
+      - name: endereco_latitude
+        description: "Latitude do estabelecimento para georreferenciamento."
+      - name: endereco_longitude
+        description: "Longitude do estabelecimento para georreferenciamento."
+
+      # Status
+      - name: ativa
+        description: "Indica o status operacional do estabelecimento ('sim' para ativo, 'não' para inativo)."
+
+      # Prontuário
+      - name: prontuario_tem
+        description: "Indica se o estabelecimento mantém prontuários dos pacientes."
+      - name: prontuario_versao
+        description: "Versão do prontuário utilizado pelo estabelecimento."
+      - name: prontuario_estoque_tem_dado
+        description: "Indica se os prontuários contêm dados disponíveis."
+      - name: prontuario_estoque_motivo_sem_dado
+        description: "Motivo pelo qual os prontuários não contêm dados."
+
+      # Informações de Contato
+      - name: telefone
+        description: "Número de telefone principal para contato com o estabelecimento."
+      - name: email
+        description: "Endereço de e-mail principal do estabelecimento."
+      - name: facebook
+        description: "Página do Facebook do estabelecimento."
+      - name: instagram
+        description: "Perfil do Instagram do estabelecimento."
+      - name: twitter
+        description: "Conta do Twitter do estabelecimento."
+
+      # Indicadores
+      - name: estabelecimento_sms_indicador
+        description: "Indica se o estabelecimento faz parte da rede municipal de saúde."
+      - name: vinculo_sus_indicador
+        description: "Indica se o estabelecimento possui vínculo com o SUS."
+      - name: atendimento_internacao_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de internação pelo SUS."
+      - name: atendimento_ambulatorial_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços ambulatoriais pelo SUS."
+      - name: atendimento_sadt_sus_indicador
+        description: "Indica se o estabelecimento oferece Serviços Auxiliares de Diagnóstico e Terapia (SADT) pelo SUS."
+      - name: atendimento_urgencia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de urgência pelo SUS."
+      - name: atendimento_outros_sus_indicador
+        description: "Indica se o estabelecimento oferece outros tipos de serviços pelo SUS."
+      - name: atendimento_vigilancia_sus_indicador
+        description: "Indica se o estabelecimento oferece serviços de vigilância em saúde pelo SUS."
+      - name: atendimento_regulacao_sus_indicador
+        description: "Indica se o estabelecimento atua em atividades de regulação de serviços de saúde pelo SUS."
+
+      # Metadados
+      - name: data_atualizao_registro
+        description: "Data em que o registro foi atualizado pela última vez."
+      - name: usuario_atualizador_registro
+        description: "Identificador do usuário que atualizou o registro pela última vez."
+      - name: mes_particao
+        description: "Mês utilizado para fins de particionamento dos dados."
+      - name: ano_particao
+        description: "Ano utilizado para fins de particionamento dos dados."
+      - name: data_particao
+        description: "Data específica utilizada para particionamento dos dados."
+      - name: data_carga
+        description: "Data em que os dados foram carregados no banco de dados."
+      - name: data_snapshot
+        description: "Data em que o snapshot dos dados foi capturado."
+
+      # ---------------------------  PROFISSIONAIS
+      - name: data_registro
+        description: "Data do registro"
+      - name: cpf
+        description: "CPF do profissional."
+      - name: profissional_cns
+        description: "Número do CNS (Cartão Nacional de Saúde) do profissional."
+      - name: profissional_nome
+        description: "Nome completo do profissional."
+      - name: vinculacao
+        description: "Descrição da vinculação do profissional."
+      - name: vinculo_tipo
+        description: "Tipo de vínculo do profissional."
+      - name: id_cbo
+        description: "Código Brasileiro de Ocupações (CBO) do profissional."
+      - name: cbo
+        description: "Descrição do Código Brasileiro de Ocupações (CBO) do profissional."
+      - name: id_cbo_familia
+        description: "Código da família CBO do profissional."
+      - name: cbo_familia
+        description: "Descrição da família do Código Brasileiro de Ocupações (CBO) do profissional."
+      - name: id_registro_conselho
+        description: "Identificador de registro no conselho profissional."
+      - name: id_tipo_conselho
+        description: "Tipo de conselho do profissional."
+      - name: profissional_dados_hci
+        description: "Dados adicionais do profissional provenientes do HCI."
+      - name: endereco_profissional_hci
+        description: "Endereço do profissional proveniente do HCI."
+      - name: carga_horaria_outros
+        description: "Carga horária em outros tipos de serviços fora do ambiente hospitalar ou ambulatorial."
+      - name: carga_horaria_hospitalar
+        description: "Carga horária em ambiente hospitalar."
+      - name: carga_horaria_ambulatorial
+        description: "Carga horária em ambiente ambulatorial."
+      - name: carga_horaria_total
+        description: "Carga horária total do profissional."

--- a/models/marts/core/dimensions/rio/dim_equipamento_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_equipamento_sus_rio_historico.sql
@@ -1,0 +1,162 @@
+{{
+    config(
+        enabled=false,
+        schema="saude_cnes",
+        alias="equipamento_sus_rio_historico"
+    )
+}}
+
+with
+versao_atual as (
+    select MAX(data_particao) as versao 
+    from {{ ref("raw_cnes_web__tipo_unidade") }}
+),
+
+estabelecimentos_mrj_sus as (
+    select * from {{ ref("dim_estabelecimento_sus_rio_historico") }} where safe_cast(data_particao as string) = (select versao from versao_atual)
+),
+
+equip_non_unique as (
+  select 
+    ano,
+    mes,
+    lpad(id_estabelecimento_cnes, 7, '0') as id_cnes,
+    safe_cast(tipo_equipamento as int64) as equipamento_tipo,
+    safe_cast(id_equipamento as int64) as equipamento_especifico_tipo,
+    safe_cast(quantidade_equipamentos as int64) as equipamentos_quantidade,
+    safe_cast(quantidade_equipamentos_ativos as int64) as equipamentos_quantidade_ativos,
+
+  from {{ ref("raw_cnes_ftp__equipamento") }}
+  where indicador_equipamento_disponivel_sus = 1 and ano >= 2010 and safe_cast(id_estabelecimento_cnes as int64) in (select distinct safe_cast(id_cnes as int64) from estabelecimentos_mrj_sus)
+),
+
+equip as (
+  select distinct * from equip_non_unique
+),
+
+equip_mapping_geral as (
+  select
+    equipamento_tipo,
+    equipamento
+  from {{ref ("raw_cnes_web__tipo_equipamento") }}
+  where data_particao = (SELECT versao FROM versao_atual)
+),
+
+equip_mapping_especifico as (
+  select
+    equipamento_especifico_tipo,
+    equipamento_tipo,
+    equipamento_especifico
+  from {{ref ("raw_cnes_web__tipo_equipamento_especifico") }}
+  where data_particao = (SELECT versao FROM versao_atual)
+),
+
+final as (
+    select
+        struct (
+            estabs.ano_competencia,
+            estabs.mes_competencia,
+            data_atualizao_registro,
+            usuario_atualizador_registro,
+            mes_particao,
+            ano_particao,
+            data_particao,
+            data_carga,
+            data_snapshot
+        ) as metadados,
+
+        struct (
+            -- Identificação
+            estabs.id_cnes,
+            id_unidade,
+            nome_razao_social,
+            nome_fantasia,
+            nome_limpo,
+            nome_sigla,
+            nome_complemento,
+            cnpj_mantenedora,
+
+            -- Responsabilização
+            esfera,
+            id_natureza_juridica,
+            natureza_juridica_descr,
+            tipo_gestao,
+            tipo_gestao_descr,
+            responsavel_sms,
+            administracao,
+            diretor_clinico_cpf,
+            diretor_clinico_conselho,
+
+            -- Atributos
+            tipo_turno,
+            turno_atendimento,
+            aberto_sempre,
+
+            -- Tipagem dos Estabelecimentos (CNES)
+            id_tipo_unidade,
+            tipo,
+
+            -- Tipagem dos Estabelecimentos (DIT)
+            tipo_sms,
+            tipo_sms_simplificado,
+            tipo_sms_agrupado,
+
+            -- Tipagem dos Estabelecimentos (SUBGERAL)
+            tipo_unidade_alternativo,
+            tipo_unidade_agrupado,
+
+            -- Localização
+            id_ap,
+            ap,
+            endereco_cep,
+            endereco_bairro,
+            endereco_logradouro,
+            endereco_numero,
+            endereco_complemento,
+            endereco_latitude,
+            endereco_longitude,
+
+            -- Status
+            ativa,
+
+            -- Prontuário
+            prontuario_tem,
+            prontuario_versao,
+            prontuario_estoque_tem_dado,
+            prontuario_estoque_motivo_sem_dado,
+
+            -- Informações de contato
+            telefone,
+            email,
+            facebook,
+            instagram,
+            twitter,
+
+            -- Indicadores
+            estabelecimento_sms_indicador,
+            vinculo_sus_indicador,
+            atendimento_internacao_sus_indicador,	
+            atendimento_ambulatorial_sus_indicador,
+            atendimento_sadt_sus_indicador,
+            atendimento_urgencia_sus_indicador,  
+            atendimento_outros_sus_indicador, 
+            atendimento_vigilancia_sus_indicador,
+            atendimento_regulacao_sus_indicador
+        ) as estabelecimentos,
+
+        struct(
+            equip.equipamento_tipo,
+            equipamento,
+            equipamento_especifico_tipo,
+            equipamento_especifico,
+            equipamentos_quantidade,
+            equipamentos_quantidade_ativos
+        ) as equipamentos
+
+    from equip
+    left join estabelecimentos_mrj_sus as estabs on equip.id_cnes = estabs.id_cnes and equip.ano = estabs.ano_competencia and equip.mes = estabs.mes_competencia
+    left join equip_mapping_geral as map_geral using (equipamento_tipo)
+    left join equip_mapping_especifico as map_espec using (equipamento_tipo, equipamento_especifico_tipo)
+)
+
+select * from final

--- a/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
@@ -1,0 +1,356 @@
+{{
+    config(
+        schema="saude_cnes",
+        alias="estabelecimento_sus_rio_historico",
+        partition_by = {
+            'field': 'data_particao', 
+            'data_type': 'date',
+            'granularity': 'day'
+        }
+    )
+}}
+
+WITH
+
+-- Obtendo a data mais atual
+versao_atual AS (
+    SELECT MAX(data_particao) AS versao 
+    FROM {{ ref("raw_cnes_web__tipo_unidade") }}
+), -- OBS: Não faz mais sentido pegar a versão de alguma outra tabela, sem ser tipo_unidade?
+
+-- Obtendo todos os estabelecimentos do MRJ que possuem vinculo com o SUS
+estabelecimentos_brutos_non_unique AS (
+    SELECT
+        ano,
+        mes,
+        cep,
+        id_estabelecimento_cnes,
+        id_natureza_juridica,
+        tipo_gestao,
+        tipo_unidade,
+        tipo_turno,
+        indicador_vinculo_sus as vinculo_sus_indicador,
+        indicador_atendimento_internacao_sus as atendimento_internacao_sus_indicador,	
+        indicador_atendimento_ambulatorial_sus as atendimento_ambulatorial_sus_indicador,
+        indicador_atendimento_sadt_sus as atendimento_sadt_sus_indicador,
+        indicador_atendimento_urgencia_sus as atendimento_urgencia_sus_indicador,  
+        indicador_atendimento_outros_sus as atendimento_outros_sus_indicador, 
+        indicador_atendimento_vigilancia_sus as atendimento_vigilancia_sus_indicador,
+        indicador_atendimento_regulacao_sus as atendimento_regulacao_sus_indicador
+    FROM {{ ref("raw_cnes_ftp__estabelecimento") }}
+    WHERE 
+        ano >= 2010 
+        AND sigla_uf = "RJ"
+        AND id_municipio_6 = "330455"
+        AND (
+            indicador_vinculo_sus = 1
+            OR indicador_atendimento_internacao_sus = 1 	
+            OR indicador_atendimento_ambulatorial_sus = 1
+            OR indicador_atendimento_sadt_sus = 1
+            OR indicador_atendimento_urgencia_sus = 1 
+            OR indicador_atendimento_outros_sus = 1
+            OR indicador_atendimento_vigilancia_sus = 1
+            OR indicador_atendimento_regulacao_sus = 1
+        )
+),
+
+estabelecimentos_brutos as (
+    select distinct * from estabelecimentos_brutos_non_unique
+),
+
+-- Obtendo atributos dos estabelecimentos via tabela desnormalizada proveniente do CNES WEB
+estabelecimentos_atributos_cnes_web AS (
+    SELECT
+        id_cnes,
+        nome_razao_social,
+        nome_fantasia,
+        cnpj_mantenedora,
+        endereco_bairro,
+        endereco_logradouro,
+        endereco_numero,
+        endereco_complemento,
+        endereco_latitude,
+        endereco_longitude,
+        id_motivo_desativacao,
+        id_unidade,
+        aberto_sempre,
+        diretor_clinico_cpf,
+        diretor_clinico_conselho,
+        data_atualizao_registro,
+        usuario_atualizador_registro,
+        mes_particao,
+        ano_particao,
+        data_particao,
+        data_carga,
+        data_snapshot,
+        id_distrito_sanitario,
+        telefone,
+        email
+    FROM {{ ref("raw_cnes_web__estabelecimento") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+),
+
+-- Obtendo atributos auxiliares dos estabelecimentos via classificação interna construída pela SMS
+estabelecimentos_atributos AS (
+    SELECT
+        id_cnes,
+        indicador_estabelecimento_sms as estabelecimento_sms_indicador,
+        tipo_unidade_subgeral,
+        tipo_unidade_agrupado_subgeral,
+        esfera_subgeral,
+        area_programatica,
+        area_programatica_descr,
+        agrupador_sms,
+        tipo_sms,
+        tipo_sms_simplificado,
+        nome_limpo,
+        nome_sigla,
+        prontuario_tem,
+        prontuario_versao,
+        responsavel_sms,
+        administracao,
+        prontuario_estoque_tem_dado,
+        prontuario_estoque_motivo_sem_dado
+    FROM {{ ref("raw_sheets__estabelecimento_auxiliar") }}
+),
+
+-- Obtendo atributos de contato para os estabelecimentos
+contatos_aps AS (
+    SELECT
+        id_cnes,
+        telefone,
+        email,
+        facebook,
+        instagram,
+        twitter
+    FROM {{ ref("raw_plataforma_smsrio__estabelecimento_contato") }}
+),
+
+-- Carregando tabelas utilizadas para mapear códigos em suas descrições textuais
+tp_gestao AS (
+    SELECT * FROM UNNEST([
+        STRUCT("D" AS id_tipo_gestao, "DUPLA" AS tipo_gestao_descr),
+        STRUCT("E", "ESTADUAL"),
+        STRUCT("M", "MUNICIPAL"),
+        STRUCT("Z", "SEM GESTAO"),
+        STRUCT("S", "SEM GESTAO"),
+        STRUCT("-Z", "NAO INFORMADO")
+    ])
+),  -- Definição proveniente do CNES FTP DATASUS
+
+nat_jur AS (
+    SELECT 
+        id_natureza_juridica, 
+        descricao AS natureza_juridica_descr 
+    FROM {{ ref("raw_cnes_web__natureza_juridica") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+
+),
+
+tp_unidade AS (
+    SELECT 
+        id_tipo_unidade,
+        descricao AS tipo_unidade_descr 
+    FROM {{ ref("raw_cnes_web__tipo_unidade") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+),
+
+turno AS (
+    SELECT 
+        id_turno_atendimento, 
+        descricao AS turno_atendimento 
+    FROM {{ ref("raw_cnes_web__turno_atendimento") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+),
+
+-- Juntando todos os atributos e mappings, para enriquecer a tabela final de estabelecimentos
+estabelecimentos_final AS (
+    SELECT
+        -- Brutos FTP DATASUS
+        brutos.ano,
+        brutos.mes,
+        brutos.cep,
+        brutos.id_estabelecimento_cnes,
+        brutos.id_natureza_juridica,
+        brutos.tipo_gestao,
+        brutos.tipo_unidade,
+        brutos.tipo_turno,
+        brutos.vinculo_sus_indicador,
+        brutos.atendimento_internacao_sus_indicador,	
+        brutos.atendimento_ambulatorial_sus_indicador,
+        brutos.atendimento_sadt_sus_indicador,
+        brutos.atendimento_urgencia_sus_indicador,  
+        brutos.atendimento_outros_sus_indicador, 
+        brutos.atendimento_vigilancia_sus_indicador,
+        brutos.atendimento_regulacao_sus_indicador,
+
+        -- CNES Web
+        cnes_web.nome_razao_social,
+        cnes_web.nome_fantasia,
+        cnes_web.cnpj_mantenedora,
+        cnes_web.endereco_bairro,
+        cnes_web.endereco_logradouro,
+        cnes_web.endereco_numero,
+        cnes_web.endereco_complemento,
+        cnes_web.endereco_latitude,
+        cnes_web.endereco_longitude,
+        cnes_web.id_motivo_desativacao,
+        cnes_web.id_unidade,
+        cnes_web.aberto_sempre,
+        cnes_web.diretor_clinico_cpf,
+        cnes_web.diretor_clinico_conselho,
+        cnes_web.data_atualizao_registro,
+        cnes_web.usuario_atualizador_registro,
+        cnes_web.mes_particao,
+        cnes_web.ano_particao,
+        cnes_web.data_particao,
+        cnes_web.data_carga,
+        cnes_web.data_snapshot,
+        cnes_web.email AS email_cnes,
+        SPLIT(cnes_web.telefone, "/") AS telefone_cnes,
+
+        -- Atributos criados in house
+        estabelecimentos_atributos.estabelecimento_sms_indicador,
+        estabelecimentos_atributos.tipo_unidade_subgeral AS tipo_unidade_alternativo,
+        estabelecimentos_atributos.tipo_unidade_agrupado_subgeral AS tipo_unidade_agrupado,
+        estabelecimentos_atributos.esfera_subgeral AS esfera,
+        estabelecimentos_atributos.area_programatica AS id_ap,
+        estabelecimentos_atributos.area_programatica_descr AS ap,
+        estabelecimentos_atributos.agrupador_sms,
+        estabelecimentos_atributos.tipo_sms,
+        estabelecimentos_atributos.tipo_sms_simplificado,
+        estabelecimentos_atributos.nome_limpo,
+        estabelecimentos_atributos.nome_sigla,
+        estabelecimentos_atributos.prontuario_tem,
+        estabelecimentos_atributos.prontuario_versao,
+        estabelecimentos_atributos.responsavel_sms,
+        estabelecimentos_atributos.administracao,
+        estabelecimentos_atributos.prontuario_estoque_tem_dado,
+        estabelecimentos_atributos.prontuario_estoque_motivo_sem_dado,
+            REGEXP_REPLACE(
+            estabelecimentos_atributos.nome_limpo,
+            r'(CF |CSE |CMS |UPA 24h |POLICLINICA |HOSPITAL MUNICIPAL |COORD DE EMERGENCIA REGIONAL CER |MATERNIDADE )',
+            ''
+        ) AS nome_complemento,
+
+        -- Mappings oficiais do CNES / DATASUS
+        tp_gestao.tipo_gestao_descr,
+        nat_jur.natureza_juridica_descr,
+        tp_unidade.tipo_unidade_descr,
+        turno.turno_atendimento,
+
+        -- Informações de Contato
+        contatos_aps.telefone AS telefone_aps,
+        contatos_aps.facebook,
+        contatos_aps.instagram,
+        contatos_aps.twitter,
+        contatos_aps.email AS email_aps,
+
+    FROM estabelecimentos_brutos AS brutos
+    LEFT JOIN estabelecimentos_atributos_cnes_web AS cnes_web ON cast(brutos.id_estabelecimento_cnes as int64) = cast(cnes_web.id_cnes as int64)
+    LEFT JOIN nat_jur ON cast(brutos.id_natureza_juridica as int64) = cast(nat_jur.id_natureza_juridica as int64)
+    LEFT JOIN tp_unidade ON cast(brutos.tipo_unidade as int64) = cast(tp_unidade.id_tipo_unidade as int64)
+    LEFT JOIN turno ON cast(brutos.tipo_turno as int64) = cast(turno.id_turno_atendimento as int64)
+    LEFT JOIN tp_gestao ON brutos.tipo_gestao = tp_gestao.id_tipo_gestao
+    LEFT JOIN estabelecimentos_atributos ON cast(brutos.id_estabelecimento_cnes as int64) = cast(estabelecimentos_atributos.id_cnes as int64)
+    LEFT JOIN contatos_aps ON cast(brutos.id_estabelecimento_cnes as int64) = cast(contatos_aps.id_cnes as int64)
+),
+
+-- Seleção final
+final as (
+    SELECT 
+        -- Identificação
+        lpad(id_estabelecimento_cnes, 7, '0') AS id_cnes,
+        id_unidade,
+        nome_razao_social,
+        nome_fantasia,
+        nome_limpo,
+        nome_sigla,
+        nome_complemento,
+        lpad(cnpj_mantenedora, 14, '0') AS cnpj_mantenedora,
+
+        -- Responsabilização
+        esfera,
+        cast(id_natureza_juridica as int64) as id_natureza_juridica,
+        natureza_juridica_descr,
+        tipo_gestao,
+        tipo_gestao_descr,
+        responsavel_sms,
+        administracao,
+        lpad(diretor_clinico_cpf, 11, '0') AS diretor_clinico_cpf,
+        diretor_clinico_conselho,
+
+        -- Atributos
+        cast(tipo_turno as int64) as tipo_turno,
+        turno_atendimento,
+        aberto_sempre,
+
+        -- Tipagem dos Estabelecimentos (CNES)
+        cast(tipo_unidade as int64) AS id_tipo_unidade,
+        tipo_unidade_descr AS tipo, -- Renomear para tipo_cnes?
+
+        -- Tipagem dos Estabelecimentos (DIT)
+        tipo_sms,
+        tipo_sms_simplificado,
+        agrupador_sms AS tipo_sms_agrupado,
+
+        -- Tipagem dos Estabelecimentos (SUBGERAL)
+        tipo_unidade_alternativo,
+        tipo_unidade_agrupado,
+
+        -- Localização
+        id_ap,
+        ap,
+        lpad(cep, 8, '0') as endereco_cep,
+        endereco_bairro,
+        endereco_logradouro,
+        endereco_numero,
+        endereco_complemento,
+        endereco_latitude,
+        endereco_longitude,
+
+        -- Status
+        CASE 
+            WHEN id_motivo_desativacao IS NULL OR id_motivo_desativacao = '' THEN 'sim' 
+            ELSE 'não' 
+        END AS ativa,
+
+        -- Prontuário
+        prontuario_tem,
+        prontuario_versao,
+        prontuario_estoque_tem_dado,
+        prontuario_estoque_motivo_sem_dado,
+
+        -- Informações de contato
+        COALESCE(telefone_aps, telefone_cnes) AS telefone,
+        COALESCE(email_aps, email_cnes) AS email,
+        facebook,
+        instagram,
+        twitter,
+
+        -- Indicadores
+        estabelecimento_sms_indicador,
+        vinculo_sus_indicador,
+        atendimento_internacao_sus_indicador,	
+        atendimento_ambulatorial_sus_indicador,
+        atendimento_sadt_sus_indicador,
+        atendimento_urgencia_sus_indicador,  
+        atendimento_outros_sus_indicador, 
+        atendimento_vigilancia_sus_indicador,
+        atendimento_regulacao_sus_indicador,
+
+        -- Metadados
+        data_atualizao_registro,
+        usuario_atualizador_registro,
+        cast(ano as int64) as ano_competencia,
+        cast(mes as int64) as mes_competencia,
+        safe_cast(mes_particao as int64) as mes_particao,
+        safe_cast(ano_particao as int64) as ano_particao,
+        parse_date('%Y-%m-%d', data_particao) as data_particao,
+        data_carga,
+        data_snapshot
+
+    FROM estabelecimentos_final
+)
+
+select * from final

--- a/models/marts/core/dimensions/rio/dim_habilitacao_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_habilitacao_sus_rio_historico.sql
@@ -1,0 +1,191 @@
+{{
+    config(
+        enabled=false,
+        schema="saude_cnes",
+        alias="habilitacao_sus_rio_historico"
+    )
+}}
+
+with 
+versao_atual as (
+    select MAX(data_particao) as versao 
+    from {{ ref("raw_cnes_web__tipo_unidade") }}
+),
+
+estabelecimentos_mrj_sus as (
+    select * from {{ ref("dim_estabelecimento_sus_rio_historico") }} where safe_cast(data_particao as string) = (select versao from versao_atual)
+),
+
+habilitacoes_non_unique as (
+  select
+    ano,
+    mes,
+    id_estabelecimento_cnes as id_cnes,
+    tipo_habilitacao as id_habilitacao,
+    nivel_habilitacao,
+    case
+      when ano_competencia_final = 9999 then 1
+      else 0
+    end as habilitacao_ativa_indicador,
+    ano_competencia_inicial as habilitacao_ano_inicio,
+    mes_competencia_inicial as habilitacao_mes_inicio,
+    case
+      when ano_competencia_final = 9999 then NULL
+      else ano_competencia_final
+    end as habilitacao_ano_fim,
+    case
+      when mes_competencia_final = 99 then NULL
+      else mes_competencia_final
+    end as habilitacao_mes_fim
+  from
+    {{ref("raw_cnes_ftp__habilitacao")}}
+  where ano >= 2010 and safe_cast(id_estabelecimento_cnes as int64) in (select distinct safe_cast(id_cnes as int64) from estabelecimentos_mrj_sus)
+),
+
+habilitacoes as (
+  select distinct * from habilitacoes_non_unique
+),
+
+habilitacoes_mapping_cnesweb AS (
+  SELECT
+    id_habilitacao,
+    habilitacao,
+    tipo_origem,
+    tipo_habilitacao
+  FROM 
+    {{ ref("raw_cnes_web__tipo_habilitacao") }}
+  WHERE
+    data_particao = (SELECT versao FROM versao_atual)
+
+    -- removendo ids ambiguos (não unicos).. são poucos
+    AND id_habilitacao NOT IN (
+      SELECT
+        id_habilitacao
+      FROM (
+        SELECT
+          id_habilitacao,
+          COUNT(*) AS contagem
+        FROM
+          {{ ref("raw_cnes_web__tipo_habilitacao") }}
+        WHERE
+          data_particao = (SELECT versao FROM versao_atual)
+        GROUP BY
+          id_habilitacao
+        HAVING
+          contagem > 1
+      )
+    )
+),
+
+final as (
+    select
+        struct (
+            estabs.ano_competencia,
+            estabs.mes_competencia,
+            data_atualizao_registro,
+            usuario_atualizador_registro,
+            mes_particao,
+            ano_particao,
+            data_particao,
+            data_carga,
+            data_snapshot
+        ) as metadados,
+
+        struct (
+            -- Identificação
+            estabs.id_cnes,
+            id_unidade,
+            nome_razao_social,
+            nome_fantasia,
+            nome_limpo,
+            nome_sigla,
+            nome_complemento,
+            cnpj_mantenedora,
+
+            -- Responsabilização
+            esfera,
+            id_natureza_juridica,
+            natureza_juridica_descr,
+            tipo_gestao,
+            tipo_gestao_descr,
+            responsavel_sms,
+            administracao,
+            diretor_clinico_cpf,
+            diretor_clinico_conselho,
+
+            -- Atributos
+            tipo_turno,
+            turno_atendimento,
+            aberto_sempre,
+
+            -- Tipagem dos Estabelecimentos (CNES)
+            id_tipo_unidade,
+            tipo,
+
+            -- Tipagem dos Estabelecimentos (DIT)
+            tipo_sms,
+            tipo_sms_simplificado,
+            tipo_sms_agrupado,
+
+            -- Tipagem dos Estabelecimentos (SUBGERAL)
+            tipo_unidade_alternativo,
+            tipo_unidade_agrupado,
+
+            -- Localização
+            id_ap,
+            ap,
+            endereco_cep,
+            endereco_bairro,
+            endereco_logradouro,
+            endereco_numero,
+            endereco_complemento,
+            endereco_latitude,
+            endereco_longitude,
+
+            -- Status
+            ativa,
+
+            -- Prontuário
+            prontuario_tem,
+            prontuario_versao,
+            prontuario_estoque_tem_dado,
+            prontuario_estoque_motivo_sem_dado,
+
+            -- Informações de contato
+            telefone,
+            email,
+            facebook,
+            instagram,
+            twitter,
+
+            -- Indicadores
+            estabelecimento_sms_indicador,
+            vinculo_sus_indicador,
+            atendimento_internacao_sus_indicador,	
+            atendimento_ambulatorial_sus_indicador,
+            atendimento_sadt_sus_indicador,
+            atendimento_urgencia_sus_indicador,  
+            atendimento_outros_sus_indicador, 
+            atendimento_vigilancia_sus_indicador,
+            atendimento_regulacao_sus_indicador
+        ) as estabelecimentos,
+
+        struct (
+            hab.id_habilitacao,
+            habilitacao,
+            habilitacao_ativa_indicador,
+            nivel_habilitacao,
+            tipo_origem,
+            tipo_habilitacao,
+            habilitacao_ano_inicio,
+            habilitacao_mes_inicio,
+            habilitacao_ano_fim,
+            habilitacao_mes_fim
+        ) as habilitacoes
+        
+    from habilitacoes as hab
+    left join habilitacoes_mapping_cnesweb as map on safe_cast(hab.id_habilitacao as int64) = safe_cast(map.id_habilitacao as int64)
+    left join estabelecimentos_mrj_sus as estabs on (hab.ano = estabs.ano_competencia and hab.mes = estabs.mes_competencia and safe_cast(hab.id_cnes as int64) = safe_cast(estabs.id_cnes as int64))
+)
+
+select * from final

--- a/models/marts/core/dimensions/rio/dim_leito_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_leito_sus_rio_historico.sql
@@ -1,0 +1,172 @@
+{{
+    config(
+        enabled=false,
+        schema="saude_cnes",
+        alias="leito_sus_rio_historico"
+    )
+}}
+
+with
+
+versao_atual as (
+    select MAX(data_particao) as versao 
+    from {{ ref("raw_cnes_web__tipo_unidade") }}
+), 
+
+leitos_mapping_cnesftp as (
+    select * from unnest([
+        STRUCT(1 as tipo_leito, "CIRURGICO" as tipo_leito_descr),
+        STRUCT(2, "CLINICO"),
+        STRUCT(3, "COMPLEMENTAR"),
+        STRUCT(4, "OBSTETRICO"),
+        STRUCT(5, "PEDIATRICO"),
+        STRUCT(6, "OUTROS"),
+        STRUCT(7, "HOSPITAL / DIA")
+    ])
+),
+
+leitos_mapping_cnesweb as (
+    select
+        id_leito_especialidade as tipo_especialidade_leito,
+        leito_especialidade as tipo_especialidade_leito_descr
+    from {{ ref("raw_cnes_web__leito") }}
+    where data_particao = (select versao from versao_atual)
+),
+
+estabelecimentos_mrj_sus as (
+    select * from {{ ref("dim_estabelecimento_sus_rio_historico") }} where safe_cast(data_particao as string) = (select versao from versao_atual)
+),
+
+leitos_mrj_sus_non_unique as (
+    select 
+        lt.tipo_leito,
+        lt.tipo_especialidade_leito,
+        lt.quantidade_total,
+        lt.quantidade_contratado,
+        lt.quantidade_sus,
+
+        ftp.tipo_leito_descr,
+        web.tipo_especialidade_leito_descr,
+        estabs.*
+
+    from  {{ ref("raw_cnes_ftp__leito") }} as lt
+    left join leitos_mapping_cnesftp as ftp on safe_cast(lt.tipo_leito as int64) = ftp.tipo_leito
+    left join leitos_mapping_cnesweb as web on safe_cast(lt.tipo_especialidade_leito as int64) = safe_cast(web.tipo_especialidade_leito as int64)
+    left join estabelecimentos_mrj_sus as estabs on lt.ano = estabs.ano_competencia and lt.mes = estabs.mes_competencia and safe_cast(lt.id_estabelecimento_cnes as int64) = safe_cast(estabs.id_cnes as int64)
+    
+    where lt.ano >= 2010 and safe_cast(lt.id_estabelecimento_cnes as int64) in (select distinct safe_cast(id_cnes as int64) from estabelecimentos_mrj_sus)
+),
+
+leitos_mrj_sus as (
+    select distinct * from leitos_mrj_sus_non_unique
+),
+
+final as (
+    select
+        STRUCT (
+            ano_competencia,
+            mes_competencia,
+            data_atualizao_registro,
+            usuario_atualizador_registro,
+            mes_particao,
+            ano_particao,
+            data_particao,
+            data_carga,
+            data_snapshot
+        ) as metadados,
+
+        STRUCT(
+            -- Identificação
+            id_cnes,
+            id_unidade,
+            nome_razao_social,
+            nome_fantasia,
+            nome_limpo,
+            nome_sigla,
+            nome_complemento,
+            cnpj_mantenedora,
+
+            -- Responsabilização
+            esfera,
+            id_natureza_juridica,
+            natureza_juridica_descr,
+            tipo_gestao,
+            tipo_gestao_descr,
+            responsavel_sms,
+            administracao,
+            diretor_clinico_cpf,
+            diretor_clinico_conselho,
+
+            -- Atributos
+            tipo_turno,
+            turno_atendimento,
+            aberto_sempre,
+
+            -- Tipagem dos Estabelecimentos (CNES)
+            id_tipo_unidade,
+            tipo,
+
+            -- Tipagem dos Estabelecimentos (DIT)
+            tipo_sms,
+            tipo_sms_simplificado,
+            tipo_sms_agrupado,
+
+            -- Tipagem dos Estabelecimentos (SUBGERAL)
+            tipo_unidade_alternativo,
+            tipo_unidade_agrupado,
+
+            -- Localização
+            id_ap,
+            ap,
+            endereco_cep,
+            endereco_bairro,
+            endereco_logradouro,
+            endereco_numero,
+            endereco_complemento,
+            endereco_latitude,
+            endereco_longitude,
+
+            -- Status
+            ativa,
+
+            -- Prontuário
+            prontuario_tem,
+            prontuario_versao,
+            prontuario_estoque_tem_dado,
+            prontuario_estoque_motivo_sem_dado,
+
+            -- Informações de contato
+            telefone,
+            email,
+            facebook,
+            instagram,
+            twitter,
+
+            -- Indicadores
+            estabelecimento_sms_indicador,
+            vinculo_sus_indicador,
+            atendimento_internacao_sus_indicador,	
+            atendimento_ambulatorial_sus_indicador,
+            atendimento_sadt_sus_indicador,
+            atendimento_urgencia_sus_indicador,  
+            atendimento_outros_sus_indicador, 
+            atendimento_vigilancia_sus_indicador,
+            atendimento_regulacao_sus_indicador
+        ) as estabelecimentos,
+
+        STRUCT (
+            tipo_leito,
+            tipo_leito_descr,
+            tipo_especialidade_leito,
+            tipo_especialidade_leito_descr,
+            quantidade_total,
+            quantidade_contratado,
+            quantidade_sus
+        ) as leitos
+
+    from leitos_mrj_sus
+    where id_cnes is not null
+    order by ano_competencia asc, mes_competencia asc, id_cnes asc, tipo_leito_descr asc, tipo_especialidade_leito_descr asc
+)
+
+select * from final

--- a/models/marts/core/dimensions/rio/dim_profissional_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_profissional_sus_rio_historico.sql
@@ -1,0 +1,222 @@
+{{
+    config(
+        enabled=false,
+        schema="saude_cnes",
+        alias="profissional_sus_rio_historico",
+        materialized="table",
+        tags=["weekly"],
+    )
+}}
+
+with
+versao_atual as (
+    select MAX(data_particao) as versao 
+    from {{ ref("raw_cnes_web__tipo_unidade") }}
+), 
+
+estabelecimentos_mrj_sus as (
+    select * from {{ ref("dim_estabelecimento_sus_rio_historico") }} where safe_cast(data_particao as string) = (select versao from versao_atual)
+),
+
+profissionais_mrj_non_unique as (
+select
+    ano,
+    mes,
+    concat(ano, '-', lpad(cast(mes as string), 2, '0')) data_registro,
+    id_estabelecimento_cnes,
+    sigla_uf,
+    case 
+        when cartao_nacional_saude = "nan" then NULL 
+        else cartao_nacional_saude 
+    end as profissional_cns,
+    nome as profissional_nome,
+    cbo_2002 as id_cbo,
+    substring(tipo_vinculo, 1, 4) as id_tipo_vinculo,
+    substring(tipo_vinculo, 1, 2) as id_vinculacao,
+    left(cbo_2002, 4) as id_cbo_familia,
+    id_registro_conselho,
+    tipo_conselho as id_tipo_conselho,
+    carga_horaria_outros,
+    carga_horaria_hospitalar,
+    carga_horaria_ambulatorial,
+    carga_horaria_outros + carga_horaria_hospitalar + carga_horaria_ambulatorial as carga_horaria_total
+
+from {{ ref("raw_cnes_ftp__profissional") }}
+
+where
+    ano >= 2010
+    and sigla_uf = "RJ"
+    and (
+        indicador_atende_sus = 1
+        or indicador_vinculo_contratado_sus = 1
+        or indicador_vinculo_autonomo_sus = 1
+    )
+    and safe_cast(id_estabelecimento_cnes as int64) in (select distinct safe_cast(id_cnes as int64) from estabelecimentos_mrj_sus)
+),
+
+profissionais_mrj as (
+    select distinct * from profissionais_mrj_non_unique
+),
+
+/* --- GERANDO CARDINALIDADE:
+profissionais_cnesweb as (
+    select
+        distinct cns,
+        id_codigo_sus,
+        nome,
+        data_atualizacao,
+        row_number() over (partition by nome, id_codigo_sus, cns order by data_atualizacao desc) as ordenacao
+    from {{ ref("raw_cnes_web__dados_profissional_sus") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual) and cns != ""
+),
+*/
+
+cbo as (select * from {{ ref("raw_datasus__cbo") }}),
+cbo_fam as (select * from {{ ref("raw_datasus__cbo_fam") }}),
+
+tipo_vinculo as (
+    select
+        concat(id_vinculacao, tipo) as codigo_tipo_vinculo,
+        descricao,
+    from {{ ref("raw_cnes_web__tipo_vinculo") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+),
+
+vinculo as (
+    select
+        id_vinculacao,
+        descricao,
+    from {{ ref("raw_cnes_web__vinculo") }}
+    WHERE data_particao = (SELECT versao FROM versao_atual)
+),
+
+profissional_dados_hci as (select distinct cns, cpf, dados, endereco from {{ ref("mart_historico_clinico__paciente") }}),
+
+final AS (
+    SELECT
+        STRUCT(
+            estabs.ano_competencia,
+            estabs.mes_competencia,
+            estabs.data_atualizao_registro,
+            estabs.usuario_atualizador_registro,
+            estabs.mes_particao,
+            estabs.ano_particao,
+            estabs.data_particao,
+            estabs.data_carga,
+            estabs.data_snapshot
+        ) AS metadados,
+
+        STRUCT(
+            -- Identificação
+            estabs.id_cnes,
+            estabs.id_unidade,
+            estabs.nome_razao_social,
+            estabs.nome_fantasia,
+            estabs.nome_limpo,
+            estabs.nome_sigla,
+            estabs.nome_complemento,
+            estabs.cnpj_mantenedora,
+
+            -- Responsabilização
+            estabs.esfera,
+            estabs.id_natureza_juridica,
+            estabs.natureza_juridica_descr,
+            estabs.tipo_gestao,
+            estabs.tipo_gestao_descr,
+            estabs.responsavel_sms,
+            estabs.administracao,
+            estabs.diretor_clinico_cpf,
+            estabs.diretor_clinico_conselho,
+
+            -- Atributos
+            estabs.tipo_turno,
+            estabs.turno_atendimento,
+            estabs.aberto_sempre,
+
+            -- Tipagem dos Estabelecimentos (CNES)
+            estabs.id_tipo_unidade,
+            estabs.tipo,
+
+            -- Tipagem dos Estabelecimentos (DIT)
+            estabs.tipo_sms,
+            estabs.tipo_sms_simplificado,
+            estabs.tipo_sms_agrupado,
+
+            -- Tipagem dos Estabelecimentos (SUBGERAL)
+            estabs.tipo_unidade_alternativo,
+            estabs.tipo_unidade_agrupado,
+
+            -- Localização
+            estabs.id_ap,
+            estabs.ap,
+            estabs.endereco_cep,
+            estabs.endereco_bairro,
+            estabs.endereco_logradouro,
+            estabs.endereco_numero,
+            estabs.endereco_complemento,
+            estabs.endereco_latitude,
+            estabs.endereco_longitude,
+
+            -- Status
+            estabs.ativa,
+
+            -- Prontuário
+            estabs.prontuario_tem,
+            estabs.prontuario_versao,
+            estabs.prontuario_estoque_tem_dado,
+            estabs.prontuario_estoque_motivo_sem_dado,
+
+            -- Informações de contato
+            estabs.telefone,
+            estabs.email,
+            estabs.facebook,
+            estabs.instagram,
+            estabs.twitter,
+
+            -- Indicadores
+            estabs.estabelecimento_sms_indicador,
+            estabs.vinculo_sus_indicador,
+            estabs.atendimento_internacao_sus_indicador,	
+            estabs.atendimento_ambulatorial_sus_indicador,
+            estabs.atendimento_sadt_sus_indicador,
+            estabs.atendimento_urgencia_sus_indicador,  
+            estabs.atendimento_outros_sus_indicador, 
+            estabs.atendimento_vigilancia_sus_indicador,
+            estabs.atendimento_regulacao_sus_indicador
+        ) AS estabelecimentos,
+
+        STRUCT(
+            --cod_sus.id_codigo_sus as profissional_codigo_sus,
+            p.data_registro,
+            hci.cpf,
+            p.profissional_cns as cns,
+            p.profissional_nome as nome,
+            vinculacao.descricao AS vinculacao,
+            tipo_vinculo.descricao AS vinculo_tipo,
+            p.id_cbo,
+            ocup.descricao AS cbo,
+            p.id_cbo_familia,
+            ocupf.descricao AS cbo_familia,
+            p.id_registro_conselho,
+            p.id_tipo_conselho,
+            p.carga_horaria_outros,
+            p.carga_horaria_hospitalar,
+            p.carga_horaria_ambulatorial,
+            p.carga_horaria_total,
+            hci.dados as profissional_dados_hci,
+            hci.endereco as endereco_profissional_hci
+            
+        ) AS profissionais
+        
+    FROM profissionais_mrj AS p
+    LEFT JOIN profissional_dados_hci AS hci ON SAFE_CAST(p.profissional_cns AS INT64) = (SELECT SAFE_CAST(cns AS INT64) FROM UNNEST(hci.cns) AS cns LIMIT 1)
+    LEFT JOIN estabelecimentos_mrj_sus AS estabs ON p.ano = estabs.ano_competencia AND p.mes = estabs.mes_competencia AND SAFE_CAST(p.id_estabelecimento_cnes AS INT64) = SAFE_CAST(estabs.id_cnes AS INT64)
+    LEFT JOIN cbo AS ocup ON p.id_cbo = ocup.id_cbo
+    LEFT JOIN cbo_fam AS ocupf ON LEFT(p.id_cbo_familia, 4) = ocupf.id_cbo_familia
+    LEFT JOIN tipo_vinculo ON p.id_tipo_vinculo = tipo_vinculo.codigo_tipo_vinculo
+    LEFT JOIN vinculo AS vinculacao ON p.id_vinculacao = vinculacao.id_vinculacao
+    -- Removido temporariamente por estar gerando cardinalidade (cada cns unico possui mais de um cod_sus associado no cnes web)
+    --left join (select * from profissionais_cnesweb where ordenacao = 1) as cod_sus on p.profissional_cns = cod_sus.cns
+)
+
+select * from final

--- a/models/marts/historico_clinico/mart_historico_clinico__paciente.sql
+++ b/models/marts/historico_clinico/mart_historico_clinico__paciente.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias="paciente",
-        schema="saude_dados_mestres",
+        schema="saude_historico_clinico",
         tag=["hci", "paciente"],
         materialized="table",
         partition_by={

--- a/models/marts/historico_clinico/mart_historico_clinico__paciente.sql
+++ b/models/marts/historico_clinico/mart_historico_clinico__paciente.sql
@@ -318,6 +318,7 @@ with
                 struct(t.ddd, t.valor, lower(t.sistema) as sistema, t.rank)
             ) as telefone,
         from telefone_dedup t
+        where t.valor is not null
         group by t.cpf
     ),
 
@@ -328,6 +329,7 @@ with
                 struct(lower(e.valor) as valor, lower(e.sistema) as sistema, e.rank)
             ) as email
         from email_dedup e
+        where e.valor is not null
         group by e.cpf
     ),
 
@@ -338,8 +340,8 @@ with
                 contato_telefone_dados.telefone, contato_email_dados.email
             ) as contato
         from all_cpfs a
-        inner join contato_email_dados using (cpf)
-        inner join contato_telefone_dados using (cpf)
+        left join contato_email_dados using (cpf)
+        left join contato_telefone_dados using (cpf)
     ),
 
     -- Endereco Dados: Merges address information

--- a/models/raw/cnes_web/_cnes_schema.yml
+++ b/models/raw/cnes_web/_cnes_schema.yml
@@ -642,3 +642,36 @@ models:
           foi tirado. É útil para rastrear as alterações históricas nos dados ao
           longo do tempo. O tipo de dados dessa coluna é datetime.
         data_type: datetime
+
+  - name: raw_cnes_web__leito
+    description: Relação de todos os tipos de leitos encontrados no CNES.
+    columns:
+      - name: id_leito_especialidade
+        description: Código de tipo específico de leito
+      - name: leito_especialidade
+        description: Descrição do tipo específico de leito
+      - name: id_leito_tipo
+        description: Código de tipo de leito
+      - name: mes_particao
+        description: Isso representa o mês da partição de dados. É usado para organizar
+          os dados por períodos de tempo para consultas e análises eficientes. O
+          valor está no formato de string.
+      - name: ano_particao
+        description: Esta coluna representa o ano da partição. É um valor de string que
+          corresponde ao ano em que os dados foram particionados. Essa
+          informação é crucial para entender o contexto temporal dos dados.
+      - name: data_particao
+        description: Esta coluna representa a data da partição. É um valor de string que
+          combina o ano e o mês da partição em uma única data (no formato
+          'AAAA-MM-01'). Essa data é importante para entender quando os dados
+          foram particionados e pode ser usada para análise baseada em tempo.
+      - name: data_carga
+        description: Esta coluna representa a data e hora em que os dados foram
+          carregados no banco de dados. É um valor de data e hora que fornece
+          informações precisas sobre quando os dados foram disponibilizados no
+          banco de dados. Essas informações são úteis para rastrear atualizações
+          de dados e garantir a atualidade dos dados.
+      - name: data_snapshot
+        description: Esta coluna representa a data e hora em que o snapshot dos dados
+          foi tirado. É útil para rastrear as alterações históricas nos dados ao
+          longo do tempo. O tipo de dados dessa coluna é datetime.

--- a/models/raw/cnes_web/_cnes_sources.yml
+++ b/models/raw/cnes_web/_cnes_sources.yml
@@ -18,3 +18,8 @@ sources:
     - name: rlEstabEquipeProf
     - name: tbTipoEquipe
     - name: tbArea
+    - name: tbNaturezaJuridica
+    - name: tbLeito
+    - name: tbSubGruposHabilitacao
+    - name: tbTipoEquipamento
+    - name: tbEquipamento

--- a/models/raw/cnes_web/raw_cnes_web__dados_profissional_sus.sql
+++ b/models/raw/cnes_web/raw_cnes_web__dados_profissional_sus.sql
@@ -1,3 +1,5 @@
+-- ATENCAO: CADA CNS UNICO PODE POSSUIR MAIS DE UM ID_CODIGO_SUS, PORTANTO, PODE GERAR CARDINALIDADE AO PERFORMAR JOINS
+
 {{
     config(
         alias="dados_profissionais_sus",

--- a/models/raw/cnes_web/raw_cnes_web__estabelecimento.sql
+++ b/models/raw/cnes_web/raw_cnes_web__estabelecimento.sql
@@ -80,5 +80,6 @@ select
         '-01'
     ) as data_particao,
     safe_cast(_data_carga as datetime) as data_carga,
-    safe_cast(_data_snapshot as datetime) as data_snapshot
+    safe_cast(concat(safe_cast(_data_snapshot as string), '-01') as datetime) as data_snapshot
+    
 from source

--- a/models/raw/cnes_web/raw_cnes_web__leito.sql
+++ b/models/raw/cnes_web/raw_cnes_web__leito.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        alias="leito_tipo",
+    )
+}}
+
+with
+    source as (
+        select * from {{ source("brutos_cnes_web_staging", "tbLeito") }}
+    )
+
+select
+    safe_cast(CO_LEITO as int64) as id_leito_especialidade,
+    safe_cast(DS_LEITO as string) as leito_especialidade,
+    safe_cast(TP_LEITO as int64) as id_leito_tipo,
+    safe_cast(_data_carga as date format 'DD/MM/YYY') as data_carga,
+    safe_cast(_data_snapshot as date format 'DD/MM/YYY') as data_snapshot,
+    safe_cast(mes_particao as string) as mes_particao,
+    safe_cast(ano_particao as string) as ano_particao,
+    concat(ano_particao, '-', mes_particao, '-', '01') as data_particao,
+from source

--- a/models/raw/cnes_web/raw_cnes_web__natureza_juridica.sql
+++ b/models/raw/cnes_web/raw_cnes_web__natureza_juridica.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        alias="natureza_juridica",
+    )
+}}
+
+with source as (select * from {{ source("brutos_cnes_web_staging", "tbNaturezaJuridica") }})
+
+select 
+    -- pk
+    safe_cast(CO_NATUREZA_JUR as string) as id_natureza_juridica,
+
+    -- common
+    safe_cast(DS_NATUREZA_JUR as string) as descricao,
+
+    -- metadata
+    safe_cast(mes_particao as string) as mes_particao,
+    safe_cast(ano_particao as string) as ano_particao,
+    concat(
+        safe_cast(ano_particao as string),
+        '-',
+        safe_cast(mes_particao as string),
+        '-01'
+    ) as data_particao,
+    safe_cast(_data_carga as datetime) as data_carga,
+    safe_cast(_data_snapshot as datetime) as data_snapshot
+
+from source

--- a/models/raw/cnes_web/raw_cnes_web__tipo_equipamento.sql
+++ b/models/raw/cnes_web/raw_cnes_web__tipo_equipamento.sql
@@ -1,0 +1,15 @@
+  {{  config(alias="tipo_equipamento")  }}
+  
+with
+source as (select * from {{ source("brutos_cnes_web_staging", "tbTipoEquipamento") }})
+
+select
+    safe_cast(CO_TIPO_EQUIPAMENTO as int64) as equipamento_tipo,
+    upper(DS_TIPO_EQUIPAMENTO) as equipamento,
+    safe_cast(_data_carga as date format 'DD/MM/YYY') as data_carga,
+    safe_cast(_data_snapshot as date format 'DD/MM/YYY') as data_snapshot,
+    safe_cast(mes_particao as string) as mes_particao,
+    safe_cast(ano_particao as string) as ano_particao,
+    concat(ano_particao, '-', mes_particao, '-', '01') as data_particao
+
+from source

--- a/models/raw/cnes_web/raw_cnes_web__tipo_equipamento_especifico.sql
+++ b/models/raw/cnes_web/raw_cnes_web__tipo_equipamento_especifico.sql
@@ -1,0 +1,16 @@
+  {{  config(alias="tipo_equipamento_especifico")  }}
+  
+with
+source as (select * from {{ source("brutos_cnes_web_staging", "tbEquipamento") }})
+
+select
+    safe_cast(CO_EQUIPAMENTO as int64) as equipamento_especifico_tipo,
+    safe_cast(CO_TIPO_EQUIPAMENTO as int64) as equipamento_tipo,
+    upper(DS_EQUIPAMENTO) as equipamento_especifico,
+    safe_cast(_data_carga as date format 'DD/MM/YYY') as data_carga,
+    safe_cast(_data_snapshot as date format 'DD/MM/YYY') as data_snapshot,
+    safe_cast(mes_particao as string) as mes_particao,
+    safe_cast(ano_particao as string) as ano_particao,
+    concat(ano_particao, '-', mes_particao, '-', '01') as data_particao
+
+from source

--- a/models/raw/cnes_web/raw_cnes_web__tipo_habilitacao.sql
+++ b/models/raw/cnes_web/raw_cnes_web__tipo_habilitacao.sql
@@ -1,0 +1,24 @@
+-- ATENCAO: ID_HABILITACAO NAO É UNIQUE, PORTANTO PODE GERAR CARDINALIDADE AO SER UTILIZADO EM JOINS
+
+{{
+    config(
+        alias="tipo_habilitacao",
+    )
+}}
+
+with
+source as (
+    select * from {{ source("brutos_cnes_web_staging", "tbSubGruposHabilitacao") }}
+)
+
+select
+    safe_cast(CO_CODIGO_GRUPO as int64) as id_habilitacao,
+    UPPER(NO_DESCRICAO_GRUPO) as habilitacao,
+    TP_ORIGEM as tipo_origem,
+    TP_HABILITACAO as tipo_habilitacao,
+    safe_cast(_data_carga as date format 'DD/MM/YYY') as data_carga,
+    safe_cast(_data_snapshot as date format 'DD/MM/YYY') as data_snapshot,
+    safe_cast(mes_particao as string) as mes_particao,
+    safe_cast(ano_particao as string) as ano_particao,
+    concat(ano_particao, '-', mes_particao, '-', '01') as data_particao,
+from source

--- a/models/raw/plataforma_smsrio/_plataforma_smsrio_sources.yml
+++ b/models/raw/plataforma_smsrio/_plataforma_smsrio_sources.yml
@@ -9,7 +9,7 @@ sources:
       - name: materiais_almoxarifado_dengue
       - name: equipe_contato
       - name: estabelecimento_contato
-      - name: paciente_eventos
+      - name: paciente_cadastro_eventos
         loaded_at_field: "CAST(source_updated_at AS TIMESTAMP)"
         filter: "date_diff( CAST(data_particao AS TIMESTAMP), current_timestamp, day) < 2"
         freshness:

--- a/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente.sql
+++ b/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente.sql
@@ -18,7 +18,7 @@
 with
     events_from_window as (
         select *
-        from {{ source("brutos_plataforma_smsrio_staging", "paciente_eventos") }}
+        from {{ source("brutos_plataforma_smsrio_staging", "paciente_cadastro_eventos") }}
         {% if is_incremental() %} where data_particao > '{{seven_days_ago}}' {% endif %}
     ),
     events_ranked_by_freshness as (
@@ -55,7 +55,7 @@ select
     safe_cast(NULLIF(NULLIF(data__cod_pais_nasc, ''), 'None') as string) as codigo_pais_nascimento,
 
     -- Endereço
-    safe_cast(NULLIF(NULLIF(data__end_tp_logrado_cod, ''), 'None') as string) as endereco_tipo_logradouro,
+    safe_cast(NULLIF(NULLIF(data__end_tp_logrado_nm, ''), 'None') as string) as endereco_tipo_logradouro,
     safe_cast(NULLIF(NULLIF(data__end_cep, ''), 'None') as string) as endereco_cep,
     safe_cast(NULLIF(NULLIF(data__end_logrado, ''), 'None') as string) as endereco_logradouro,
     safe_cast(NULLIF(NULLIF(data__end_numero, ''), 'None') as string) as endereco_numero,

--- a/models/raw/sheets/_sheets_schema.yml
+++ b/models/raw/sheets/_sheets_schema.yml
@@ -8,10 +8,19 @@ models:
         data_tests:
           - unique:
               name: raw_sheets__estabelecimento_auxiliar__id_cnes__unique
+# comentando momentaneamente até finalizarmos a tabela auxiliar
+#          - relationships:
+#              name: raw_sheets__estabelecimento_auxiliar__id_cnes__relationship
+#              to: ref('dim_estabelecimento_sus_rio_historico')
+#              field: id_cnes
+      - name: indicador_estabelecimento_sms
+        description: Indica se o estabelecimento é pertencente a rede assistencial da Secretaria Municipal de Saúde do Rio de Janeiro (1=SIM, 0=NAO)
       - name: tipo_sms
         description: Classificação alternativa ao CNES de tipos de unidades
       - name: tipo_sms_simplificado
         description: Classificação alternativa ao CNES de tipos de unidades abreviada
+      - name: agrupador_sms
+        description: Classificação alternativa ao CNES
       - name: nome_fantasia
         description: Nome fantasia de unidade de saúde
       - name: nome_limpo
@@ -35,6 +44,15 @@ models:
         description: Subcretaria responsável dentro da SMS
       - name: administracao
         description: Administradora da unidade de saúde.
+      - name: tipo_unidade_subgeral
+        description: Classificação alternativa ao CNES de tipos de unidades
+      - name: tipo_unidade_agrupado_subgeral
+        description: Classificação alternativa ao CNES
+      - name: esfera_subgeral
+        description: Classificação alternativa de esfera 
+      - name: area_programatica_descr
+        description: Descrição da Área Programática
+      
   - name: raw_sheets__material_mestre
     description: Tabela cadastral de materiais da SMS-Rio
     columns:

--- a/models/raw/sheets/raw_sheets__estabelecimento_auxiliar.sql
+++ b/models/raw/sheets/raw_sheets__estabelecimento_auxiliar.sql
@@ -16,6 +16,8 @@ select
     format("%07d", cast(id_cnes as int64)) as id_cnes,  -- fix cases where 0 on the left is lost
 
     -- Common fields
+    cast(indicador_estabelecimento_sms as int64) as indicador_estabelecimento_sms,
+
     if(agrupador_sms = "nan", null, agrupador_sms) as agrupador_sms,
     if(tipo_sms = "nan", null, tipo_sms) as tipo_sms,
     if(tipo_sms_simplificado = "nan", null, tipo_sms_simplificado) as tipo_sms_simplificado,
@@ -29,6 +31,11 @@ select
     if(prontuario_estoque_motivo_sem_dado = "nan", null, prontuario_estoque_motivo_sem_dado) as prontuario_estoque_motivo_sem_dado,
     if(responsavel_sms = "nan", null, responsavel_sms) as responsavel_sms,
     if(administracao = "nan", null, administracao) as administracao,
+
+    tipo_unidade_subgeral,
+    tipo_unidade_agrupado_subgeral,
+    esfera_subgeral,
+    area_programatica_descr
 
 from source
 


### PR DESCRIPTION
Este PR inclui as seguintes modificações e correções no sistema de integração de dados de pacientes:

- [x] **Atualização da tabela de Paciente Integrado**: O dataset foi modificado para usar o novo nome `saude_historico_clinico`, garantindo consistência com o novo esquema de dados.
   
- [x] **Correção de código do IBGE em campos de endereço**: Correção aplicada utilizando a tabela `basedosdados.br_bd_diretorios_brasil.municipio`, com *join* na coluna `id_municipio_6`. No caso da vitacare que contem a cidade e o numero foi removido tudo apos a [ que contem o numero.

- [x] **Correção de e-mails na lista de telefones**: Remoção dos e-mails que estavam listados erroneamente como telefones na tabela da SMSRio, realocando os dados para a coluna correta de e-mail.

- [x] **Eliminação de duplicatas de telefones e e-mails**: Correção de registros que apresentavam telefones e e-mails duplicados na tabela de Pacientes. O erro ocorria devido a um *typo* na deduplicação de e-mails, que estava utilizando a CTE de telefones em vez de e-mails.

- [x] **Código no campo `endereco.tipo_logradouro`**:
   - Pedro já atualizou o modelo `raw_plataforma_smsrio__paciente `
   - Próximo passo: Trás a master pra sua branch e materializa a tabela ` dbt run --select raw_plataforma_smsrio__paciente --full-refresh`

- [x] ~~**Tratamento de telefones com notação científica**: Aguardando investigação e tratamento.~~

- [x] **Deduplicacao de email/telefone**: Agora o join dos contatos acontece apos o agrupamento individual do telefone e contato

- [x] **Deduplicacao de equipe_familia**: Agora o join final da equipe da familia leva em consideracao o id_cnes, evitando duplicidade devido ao cpf
