### PR TITLE
Fix/saude dados mestres vinculo

### DIFF
--- a/models/intermediate/core/int_profissional_saude__vinculo_estabelecimento_serie_historica.sql
+++ b/models/intermediate/core/int_profissional_saude__vinculo_estabelecimento_serie_historica.sql
@@ -36,11 +36,11 @@ with
             row_number() over (
             partition by 
                 id_unidade, 
-                id_profissional_sus 
+                id_profissional_sus
             order by data_atualizacao desc
-            ) as ordenacao,
+            ) as ordenacao
          from {{ ref("raw_cnes_web__carga_horaria_sus") }}
-         where atende_sus_indicador = true
+         where atende_sus_indicador is true
     ),
 
      estabelecimento as (
@@ -48,37 +48,16 @@ with
         from {{ ref("raw_cnes_web__estabelecimento") }}
         where id_estado_gestor = '33' -- RJ
      ),
-
-    profissional_ftp as (
-        select
-            concat(ano, '-', lpad(cast(mes as string), 2, '0')) data_registro,
-            id_estabelecimento_cnes,
-            sigla_uf,
-            {{clean_numeric_string('cartao_nacional_saude')}} as profissional_cns,
-            {{clean_numeric_string('nome')}} as profissional_nome,
-            cbo_2002 as id_cbo,
-            substring(tipo_vinculo, 1, 4) as id_tipo_vinculo,
-            substring(tipo_vinculo, 1, 2) as id_vinculacao,
-            left(cbo_2002, 4) as id_cbo_familia,
-            {{clean_numeric_string('id_registro_conselho')}} as id_registro_conselho,
-            tipo_conselho as id_tipo_conselho,
-            carga_horaria_outros,
-            carga_horaria_hospitalar,
-            carga_horaria_ambulatorial
-        from {{ ref("raw_cnes_ftp__profissional") }}
-        where
-            ano >= 2008
-            and sigla_uf = "RJ"
-            and (
-                indicador_atende_sus = 1
-                or indicador_vinculo_contratado_sus = 1
-                or indicador_vinculo_autonomo_sus = 1
-            )
-    ),
     
-    cbo as (select * from {{ ref("raw_datasus__cbo") }}),
+    cbo as (
+        select * 
+        from {{ ref("raw_datasus__cbo") }}
+    ),
 
-    cbo_fam as (select * from {{ ref("raw_datasus__cbo_fam") }}),
+    cbo_fam as (
+        select * 
+        from {{ ref("raw_datasus__cbo_fam") }}
+    ),
 
     tipo_vinculo as (
         select
@@ -118,7 +97,7 @@ select
     p.carga_horaria_outros,
     p.carga_horaria_hospitalar,
     p.carga_horaria_ambulatorial,
-    p.data_atualizacao
+    cod_sus.data_atualizacao
 
 from profissional_web as p
 left join estabelecimento as e on p.id_unidade = e.id_unidade
@@ -133,3 +112,6 @@ left join
 left join
     (select * from profissional_sus where ordenacao = 1) as cod_sus
     on p.id_profissional_sus = cod_sus.id_codigo_sus
+qualify row_number() over (
+    partition by id_cnes, id_profissional_sus 
+    order by data_atualizacao desc) = 1

--- a/models/marts/core/dimensions/dim_vinculo_profissional_saude_estabelecimento.sql
+++ b/models/marts/core/dimensions/dim_vinculo_profissional_saude_estabelecimento.sql
@@ -15,7 +15,7 @@ with
     estabelecimentos as (select distinct id_cnes from {{ ref("dim_estabelecimento") }})
 
 
-select
+select distinct 
     p.id_cnes,
     profissional_codigo_sus as id_profissional_sus,
     profissional_cns,
@@ -50,7 +50,7 @@ select
     carga_horaria_outros,
     carga_horaria_hospitalar,
     carga_horaria_ambulatorial,
-    data_registro as data_ultima_atualizacao
+    data_atualizacao
 
 from profissional_serie_historica as p
 inner join estabelecimentos as estabelecimentos 

--- a/models/raw/cnes_web/_cnes_schema.yml
+++ b/models/raw/cnes_web/_cnes_schema.yml
@@ -675,3 +675,54 @@ models:
         description: Esta coluna representa a data e hora em que o snapshot dos dados
           foi tirado. É útil para rastrear as alterações históricas nos dados ao
           longo do tempo. O tipo de dados dessa coluna é datetime.
+  
+  - name: raw_cnes_web__carga_horaria_sus
+    description: Tabela de carga horária do profissional.
+    columns:
+      - name: id_unidade
+        description: Código do Estabelecimento de saúde
+      - name: id_profissional_sus
+        description: Código do profissional de saúde.
+      - name: id_cbo
+        description: Código Brasileiro de Ocupação.
+      - name: atende_sus_indicador
+        description: Indica se o profissional faz atendimento SUS.
+      - name: vinculacao
+        description: > 
+          Indica a vinculação, o tipo e o sub tipo de vínculo do
+          Profissional com o Estabelecimento de Saúde.
+      - name: conselho_tipo
+        description: Código do Orgão Emissor.
+      - name: id_registro_conselho
+        description: Número do Registro no Conselho de Classe.
+      - name: sigla_uf_crm
+        description: UF do CRM.
+      - name: preceptor_indicador
+        description: Indica se o profissional é preceptor na equipe.
+      - name: residente_indicador
+        description: Indica se o profissional é residente na equipe.
+      - name: cnpj_empregador
+        description: Número do CNPJ do Empregador.
+      - name: carga_horaria_ambulatorial
+        description: Quantidade de carga horária ambulatorial.
+      - name: carga_horaria_hospitalar
+        description: Quantidade de carga horária hospitalar.
+      - name: carga_horaria_outros
+        description: Quantidade de carga horária de Outros.
+      - name: data_atualizacao
+        description: Data da última atualização do registro.
+      - name: data_atualizacao_origem
+        description: Data da primeira entrada no Banco de Produção Federal
+      - name: data_carga
+        description: >
+          Esta coluna representa a data e hora em que os dados foram
+          carregados no banco de dados. É um valor de data e hora que fornece
+          informações precisas sobre quando os dados foram disponibilizados no
+          banco de dados. Essas informações são úteis para rastrear atualizações
+          de dados e garantir a atualidade dos dados.
+      - name: data_snapshot
+        description: Momento no qual foi feito o snapshot do registro.
+      - name: ano_particao
+        description: Ano da partição de dados.
+      - name: mes_particao
+        description: Mês da partição de dados.

--- a/models/raw/cnes_web/_cnes_sources.yml
+++ b/models/raw/cnes_web/_cnes_sources.yml
@@ -23,3 +23,4 @@ sources:
     - name: tbSubGruposHabilitacao
     - name: tbTipoEquipamento
     - name: tbEquipamento
+    - name: tbCargaHorariaSus

--- a/models/raw/cnes_web/raw_cnes_web__carga_horaria_sus.sql
+++ b/models/raw/cnes_web/raw_cnes_web__carga_horaria_sus.sql
@@ -1,0 +1,43 @@
+{{
+    config(
+        alias="carga_horaria_sus",
+    )
+}}
+
+
+with 
+
+source as (
+    select 
+        * 
+    from {{ source("brutos_cnes_web_staging", "tbCargaHorariaSus") }}
+),
+
+
+renamed as (
+    select
+        {{ process_null('co_unidade') }} as id_unidade,
+        {{ process_null('co_profissional_sus') }} as id_profissional_sus,
+        {{ process_null('co_cbo') }} as id_cbo,
+        if (tp_sus_nao_sus = 'S', true, false) as atende_sus_indicador,
+        {{ process_null('ind_vinculacao') }} as vinculacao,
+        {{ process_null('qt_carga_horaria_ambulatorial') }} as carga_horaria_ambulatorial,
+        {{ process_null('qt_carga_horaria_outros') }} as carga_horaria_outros,
+        {{ process_null('qt_carga_hor_hosp_sus') }} as carga_horaria_hospitalar,
+        {{ process_null('co_conselho_classe') }} as conselho_tipo,
+        {{ process_null('nu_registro') }} as id_registro_conselho,
+        {{ process_null('sg_uf_crm') }} as sigla_uf_crm,
+        if (tp_preceptor = '1', true, false) as preceptor_indicador,
+        if (tp_residente = '1', true, false) as residente_indicador,
+        {{ process_null('nu_cnpj_detalhamento_vinculo') }} as cnpj_empregador,
+        safe_cast(dt_atualizacao_origem as date format 'DD/MM/YYYY') as data_atualizacao_origem,
+        safe_cast(dt_atualizacao as date format 'DD/MM/YYYY') as data_atualizacao,
+        {{ process_null('ano_particao') }} as ano_particao,
+        {{ process_null('mes_particao') }} as mes_particao,
+        cast(_data_carga as datetime) as data_carga,
+        {{ process_null('_data_snapshot')}} as data_snapshot
+
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
- Adição do modelo para a tabela de CargaHorariaSus em `brutos_cnes_web`
- Adição do das descrições da tabela `carga_horaria_sus` no arquivo de schema
- Alteração na construção da tabela `int_profissional_saude__vinculo_estabelecimento_serie_historica` para utilizar `brutos_cnes_web.carga_horaria_sus` ao invés de `brutos_cnes_ftp.profissional`