### PR TITLE
[Vitacare Histórico] - Correção na lógica de deduplicação em tabelas com multiplos registros para um atendimento

### DIFF
--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__condicao.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__condicao.sql
@@ -29,13 +29,8 @@ WITH
     condicoes_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_condicoes
-        )
-        WHERE rn = 1
+        FROM source_condicoes 
+        qualify row_number() over (partition by id_prontuario_global, cod_cid10 order by extracted_at desc) = 1 
     ),
 
     fato_condicoes AS (
@@ -44,12 +39,9 @@ WITH
             id_prontuario_global,
             REPLACE(acto_id, '.0', '') AS id_prontuario_local,
             id_cnes,
-
             cod_cid10 AS cod_cid10,
             estado AS estado,
             SAFE_CAST((data_diagnostico) AS DATETIME) AS data_diagnostico,
-   
-   
             extracted_at AS loaded_at,
             DATE(SAFE_CAST(extracted_at AS DATETIME)) AS data_particao
         FROM condicoes_deduplicados

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__encaminhamento.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__encaminhamento.sql
@@ -12,7 +12,6 @@
 }}
 
 WITH
-
     source_encaminhamentos AS (
         SELECT 
             CONCAT(
@@ -24,18 +23,12 @@ WITH
         FROM {{ source('brutos_prontuario_vitacare_historico_staging', 'encaminhamentos') }} 
     ),
 
-
       -- Using window function to deduplicate encaminhamentos
     encaminhamentos_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_encaminhamentos
-        )
-        WHERE rn = 1
+        FROM source_encaminhamentos 
+        qualify row_number() over (partition by id_prontuario_global, encaminhamento_especialidade order by extracted_at desc) = 1
     ),
 
     fato_encaminhamentos AS (
@@ -44,9 +37,7 @@ WITH
             id_prontuario_global,
             REPLACE(acto_id, '.0', '') AS id_prontuario_local,
             id_cnes,
-
             encaminhamento_especialidade,
-   
             extracted_at AS loaded_at,
             DATE(SAFE_CAST(extracted_at AS DATETIME)) AS data_particao
         FROM encaminhamentos_deduplicados

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__indicador.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__indicador.sql
@@ -29,13 +29,8 @@ WITH
     indicadores_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_indicadores
-        )
-        WHERE rn = 1
+        FROM source_indicadores 
+        qualify row_number() over (partition by id_prontuario_global, indicadores_nome order by extracted_at desc) = 1
     ),
 
     fato_indicadores AS (

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__prescricao.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__prescricao.sql
@@ -29,13 +29,8 @@ WITH
     prescricoes_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_prescricoes
-        )
-        WHERE rn = 1
+        FROM source_prescricoes
+        qualify row_number() over (partition by id_prontuario_global, cod_medicamento order by extracted_at desc) = 1
     ),
 
     fato_prescricoes AS (

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__procedimentos_clinicos.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__procedimentos_clinicos.sql
@@ -29,13 +29,8 @@ WITH
     procedimentos_clinicos_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_procedimentos_clinicos
-        )
-        WHERE rn = 1
+        FROM source_procedimentos_clinicos
+        qualify row_number() over (partition by id_prontuario_global, co_procedimento order by extracted_at desc) = 1
     ),
 
     fato_procedimentos_clinicos AS (

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__solicitacaoexame.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__solicitacaoexame.sql
@@ -29,13 +29,8 @@ WITH
     solicitacaoexames_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_solicitacaoexames
-        )
-        WHERE rn = 1
+        FROM source_solicitacaoexames 
+        qualify row_number() over (partition by id_prontuario_global, cod_exame order by extracted_at desc) = 1
     ),
 
     fato_solicitacaoexames AS (

--- a/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__vacina.sql
+++ b/models/raw/prontuario_vitacare_historico/raw_prontuario_vitacare_historico__vacina.sql
@@ -29,13 +29,8 @@ WITH
     vacinas_deduplicados AS (
         SELECT
             *
-        FROM (
-            SELECT
-                *,
-                ROW_NUMBER() OVER (PARTITION BY id_prontuario_global ORDER BY extracted_at DESC) AS rn
-            FROM source_vacinas
-        )
-        WHERE rn = 1
+        FROM source_vacinas 
+        qualify row_number() over (partition by id_prontuario_global order by extracted_at desc) = 1
     ),
 
     fato_vacinas AS (


### PR DESCRIPTION
Alteração na lógica de deduplicação de tabelas que referentes a tópicos gerados em um atendimento.

A lógica anterior não levava em conta a possibilidade de haver mais de um tipo de registro para um atendimento.

Exemplo: Múltiplas prescrições de medicamento para um atendimento ou múltiplos indicadores de saúde medidos em um atendimento. 

Tabelas com modelos alterados:
- condicao
- encaminhamento
- indicador
- prescricao
- procedimentos_clinicos
- solicitacaoexame
- vacina