### PR TITLE
[Vitacare] inconsistência Ficha a

### DIFF
--- a/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_historico.sql
+++ b/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_historico.sql
@@ -27,6 +27,7 @@ with
             ut_id as id_paciente,
             npront as numero_prontuario,
             
+            id_cnes as unidade_cadastro
             ap as ap_cadastro,
 
             nome,


### PR DESCRIPTION
Corrige uma inconsistência entre os modelos ficha_a_historico e ficha_a_continuo, adicionando a coluna unidade_cadastro, que estava ausente no histórico.