### PR TITLE
[SMS Rio] - Melhoria na ordenação e seleção por rank de CNS e telefones de pacientes

### DIFF
--- a/models/marts/dit/historico_clinico_app/mart_historico_clinico_app__paciente.sql
+++ b/models/marts/dit/historico_clinico_app/mart_historico_clinico_app__paciente.sql
@@ -61,7 +61,16 @@ with
             dados.genero as gender,
             dados.raca as race,
             dados.obito_indicador as deceased,
-            {{ padronize_telefone("contato.telefone[safe_offset(0)].valor")}} as phone,
+            case 
+                when contato.telefone[safe_offset(0)].rank = 1
+                    then {{ padronize_telefone("contato.telefone[safe_offset(0)].valor")}}
+                when contato.telefone[safe_offset(1)].rank = 1
+                    then {{ padronize_telefone("contato.telefone[safe_offset(1)].valor")}}
+                when contato.telefone[safe_offset(2)].rank = 1
+                    then {{ padronize_telefone("contato.telefone[safe_offset(2)].valor")}}
+                else 
+                    null
+            end as phone,
             struct(
                 equipe_saude_familia[safe_offset(0)].clinica_familia.id_cnes as cnes,
                 equipe_saude_familia[safe_offset(0)].clinica_familia.nome as name,

--- a/models/marts/dit/historico_clinico_app/mart_historico_clinico_app__paciente.sql
+++ b/models/marts/dit/historico_clinico_app/mart_historico_clinico_app__paciente.sql
@@ -61,16 +61,7 @@ with
             dados.genero as gender,
             dados.raca as race,
             dados.obito_indicador as deceased,
-            case 
-                when contato.telefone[safe_offset(0)].rank = 1
-                    then {{ padronize_telefone("contato.telefone[safe_offset(0)].valor")}}
-                when contato.telefone[safe_offset(1)].rank = 1
-                    then {{ padronize_telefone("contato.telefone[safe_offset(1)].valor")}}
-                when contato.telefone[safe_offset(2)].rank = 1
-                    then {{ padronize_telefone("contato.telefone[safe_offset(2)].valor")}}
-                else 
-                    null
-            end as phone,
+            {{ padronize_telefone("contato.telefone[safe_offset(0)].valor")}} as phone,
             struct(
                 equipe_saude_familia[safe_offset(0)].clinica_familia.id_cnes as cnes,
                 equipe_saude_familia[safe_offset(0)].clinica_familia.nome as name,

--- a/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_cadastro.sql
+++ b/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_cadastro.sql
@@ -9,12 +9,15 @@ with
     paciente as (
         select * from {{ ref('raw_plataforma_smsrio__paciente') }}
     ),
+
     paciente_cns as (
         select * from {{ ref('raw_plataforma_smsrio__paciente_cns') }}
     ),
+
     paciente_telefones as (
         select * from {{ ref('raw_plataforma_smsrio__paciente_telefones') }}
     ),
+
     -- --------------------------------------------------------------------------
     -- Enriquecimento de dados
     -- Os principais dados de cada paciente são os que estão no cadastro.
@@ -22,44 +25,52 @@ with
     todos_cns as (
         select
             cns,
-            cns as cns_provisorio
+            cns as cns_provisorio,
+            updated_at
         from paciente
         union all
         select
             cns,
-            cns_provisorio
+            cns_provisorio,
+            updated_at
         from paciente_cns
     ),
+
     todos_telefones as (
         select
             cns,
             telefone,
-            tp_telefone
+            tp_telefone,
+            updated_at
         from paciente
         union all
         select
             cns,
             telefone,
-            tp_telefone
+            tp_telefone,
+            cast(updated_at as datetime)
         from paciente_telefones
     ),
+
     -- --------------------------------------------------------------------------
     -- Agrupamento de dados
     -- --------------------------------------------------------------------------
     telefone_lista as (
         select
             cns,
-            array_agg(telefone ignore nulls) as telefone_lista
+            array_agg(telefone ignore nulls order by updated_at desc) as telefone_lista -- Ordenação de telefones pela data de atualização
         from todos_telefones
         group by cns
     ),
+
     cns_lista as (
         select
             cns,
-            array_agg(cns_provisorio ignore nulls) as cns_provisorio_lista
+            array_agg(cns_provisorio ignore nulls by updated_at desc) as cns_provisorio_lista -- Ordenação de cns pela data de atualização
         from todos_cns
         group by cns
     ),
+    
     -- --------------------------------------------------------------------------
     -- Enriquecimento de dados
     -- --------------------------------------------------------------------------

--- a/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_cns.sql
+++ b/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_cns.sql
@@ -26,4 +26,4 @@ with
             datetime(timestamp(datalake_loaded_at), 'America/Sao_Paulo') as loaded_at
         from most_recent
     )
-select * from source
+select * from transform

--- a/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_telefones.sql
+++ b/models/raw/plataforma_smsrio/raw_plataforma_smsrio__paciente_telefones.sql
@@ -18,9 +18,8 @@ with
             safe_cast(cns as string) as cns,
             safe_cast(tp_telefone as string) as tp_telefone,
             safe_cast(telefone as string) as telefone,
-
             timestamp_add(datetime(timestamp({{process_null('timestamp')}}), 'America/Sao_Paulo'),interval 3 hour) as updated_at,
             datetime(timestamp(datalake_loaded_at), 'America/Sao_Paulo') as loaded_at
         from most_recent
     )
-select * from source
+select * from transform


### PR DESCRIPTION
Neste PR, são implementadas melhorias na ordenação e na lógica de ranqueamento de CNS e números de telefone, com base na data de atualização dos registros. Essa alteração tem como objetivo resolver divergências observadas entre os dados de produção e desenvolvimento na tabela `app_historico_clinico.paciente`.

## Problema

Foi identificada uma inconsistência nos números de telefone associados a um mesmo CPF na tabela `app_historico_clinico.paciente`, com diferenças entre os ambientes de desenvolvimento e produção.

## Possível causa

A origem do problema está na utilização do comando `UNNEST` para desmembrar a coluna `telefone_lista` da tabela `brutos_plataforma_smsrio.paciente_cadastro`. Como o `UNNEST` padrão não preserva a ordem original dos elementos do array, isso gerava diferenças no ranqueamento dos telefones entre os ambientes. A coluna `telefone_lista` reúne os contatos de um mesmo paciente e é utilizada no modelo `int_historico_clinico__paciente__smsrio`, responsável por ranquear CNS e contatos, servindo como base para os modelos `mart` e `app`.

## Solução implementada

A solução adotada neste PR foi utilizar o `UNNEST` com `OFFSET`, o que permite preservar a posição original de cada elemento no array. Essa posição passou a ser utilizada como critério adicional na lógica de ranqueamento. Para isso, foram feitas alterações na camada bruta, assegurando que a ordem dos elementos no array reflita o grau de atualização ("frescor") de cada contato.

A mesma abordagem foi aplicada ao ranqueamento de CNS.

Com isso, busca-se introduzir maior determinismo no processo de ranqueamento de telefones e CNS, garantindo consistência entre os ambientes.
