### PR TITLE
[Vacinacao] Test Warnings

### DIFF
--- a/models/intermediate/dit/historico_clinico/vacinacao/_int_historico_clinico__vacinacao__vitacare.yml
+++ b/models/intermediate/dit/historico_clinico/vacinacao/_int_historico_clinico__vacinacao__vitacare.yml
@@ -14,18 +14,24 @@ models:
             original dos dados de origem. Este id é usado para identificar
             exclusivamente cada registro de vacinação.
           data_tests:
-            - unique:
-                name: int_historico_clinico__vacina__id__unique
-                config:
-                  severity: warn
-                  warn_if: ">1000"
             - not_null:
                 name: int_historico_clinico__vacina__id__not_null
                 config:
                   severity: warn
-                  warn_if: ">1"
+                  warn_if: ">10"
           data_type: string
           quote: true
+        - name: id_surrogate
+          description: Esta é uma chave substituta para cada registro. É um valor hash gerado a partir do
+            id_cnes, vacina, data da aplicacao e do id original dos dados de origem. Esta chave substituta 
+            é usada para fins de data warehousing para garantir a integridade dos dados e lidar com 
+            mudanças nos dados de origem ao longo do tempo
+          data_tests:
+            - unique:
+                name: int_historico_clinico__vacina__id_surrogate__unique
+                config:
+                  severity: warn
+                  warn_if: ">1000"
         - name: cpf
           description: CPF do paciente.
           data_type: string

--- a/models/intermediate/dit/historico_clinico/vacinacao/int_historico_clinico__vacinacao__vitacare.sql
+++ b/models/intermediate/dit/historico_clinico/vacinacao/int_historico_clinico__vacinacao__vitacare.sql
@@ -29,6 +29,7 @@ with
     vacinacoes as (
         select
             id, 
+            id_surrogate,
             id_cnes,
             cpf,
             nome_vacina,

--- a/models/raw/prontuario_vitacare/_prontuario_vitacare_schema.yml
+++ b/models/raw/prontuario_vitacare/_prontuario_vitacare_schema.yml
@@ -744,11 +744,6 @@ models:
           original dos dados de origem. Este id é usado para identificar
           exclusivamente cada registro de vacinação.
         data_tests:
-          - unique:
-              name: raw_prontuario_vitacare__vacina__id__unique
-              config:
-                severity: warn
-                warn_if: ">1000"
           - not_null:
               name: raw_prontuario_vitacare__vacina__id__not_null
               config:


### PR DESCRIPTION
1 - WARN: raw_prontuario_vitacare__vacina__id__unique
Got 2,670,533 results, configured to warn if >1000:
O teste de unicidade falhou no campo id. Como o id é apenas a junção de cnes + código local, troquei o teste para o campo id_surrogate, que é o hash gerado a partir de cnes, código local, nome da vacina e data da aplicação.

2 - WARN: int_historico_clinico__vacina__id__unique
Got 2,670,533 results, configured to warn if >1000:
Mesmo caso do anterior: adicionei o campo id_surrogate e alterei o teste para usar esse campo.

3 - WARN: int_historico_clinico__vacina__id__not_null
Got 5 results, configured to warn if >1:
Esses casos vem do contínuo. Temos alguns registros sem cnes, o que precisa de uma investigação melhor