### PR TITLE
[API models] Fix Test Warnings and Errors

### DIFF
--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__estoque_movimento.yml
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__estoque_movimento.yml
@@ -45,7 +45,7 @@ models:
               name: raw_prontuario_vitacare_api__estoque_movimento__id_cnes__not_null
           - relationships:
               name: raw_prontuario_vitacare_api__estoque_movimento__id_cnes__relationship
-              to: ref('dim_estabelecimento')
+              to: ref('dim_estabelecimento_sus_rio_historico')
               field: id_cnes
 
       - name: id_pedido_wms

--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__estoque_posicao.yml
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__estoque_posicao.yml
@@ -52,7 +52,7 @@ models:
               name: raw_prontuario_vitacare_api__estoque_posicao__id_cnes__not_null
           - relationships:
               name: raw_prontuario_vitacare_api__estoque_posicao__id_cnes__relationship
-              to: ref('dim_estabelecimento')
+              to: ref('dim_estabelecimento_sus_rio_historico')
               field: id_cnes
 
       - name: id_lote

--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__vacinacao.sql
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__vacinacao.sql
@@ -79,6 +79,7 @@ with
 
             _loaded_at as loaded_at
         from source
+        where json_extract_scalar(data,'$.nCnesUnidade') is not null
     ),
 
     casted as (

--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__vacinacao.yml
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__vacinacao.yml
@@ -12,15 +12,10 @@ models:
         description: Identificador único do registro, composto por id_cnes e id_vacinacao_local.
         data_type: string
         data_tests:
-          - unique:
-              name: raw_prontuario_vitacare_api__vacinacao__id_vacinacao__unique
-              config:
-                severity: warn
           - not_null:
               name: raw_prontuario_vitacare_api__vacinacao__id_vacinacao__not_null
               config:
                 severity: warn
-
       - name: id_surrogate
         description: >
           Chave substituta gerada a partir do id_cnes, id_vacinacao_local e paciente_cns,


### PR DESCRIPTION
### ❌Correção de testes com erro (FAIL)

**1. `raw_prontuario_vitacare_api__estoque_movimento__id_cnes__relationship`**

* **Problema:** 2.966 registros falharam na checagem de relacionamento porque havia `id_cnes` no fato `estoque_movimento` sem correspondência na `dim_estabelecimento`.
* **Causa:** O teste usava a dimensão **dim\_estabelecimento**, que é restrita ao período corrente e a estabelecimentos SMS, enquanto o fato contém eventos históricos e CNES não-SMS. 
* **Solução:** O teste agora usa **dim\_estabelecimento\_sus\_rio\_historico** para validar a correspondencia do cnes


**2. `raw_prontuario_vitacare_api__estoque_posicao__id_cnes__relationship`**

* **Problema:** 10.558 registros falharam pelo mesmo motivo do teste anterior.
* **Solução:** Ajuste idêntico ao acima, uso da dimensão **histórica**


### ⚠️Correção de testes com aviso (WARN)

**1. `raw_prontuario_vitacare_api__vacinacao__id_vacinacao__unique`**

* **Problema:** 387 registros duplicados.
* **Solução:** Removido o teste de unicidade para `id_vacinacao` e deixei o teste via `id_surrogate`.

**2. `raw_prontuario_vitacare_api__vacinacao__id_vacinacao__not_null`**

* **Problema:** 4 registros com `id_vacinacao` nulo.
* **Solução:** Adicionei o filtro para descartar registros com `cnes` nulo.
