### PR TITLE
[Estoque Posição] ADD data_particao

### DIFF
--- a/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
+++ b/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
@@ -49,7 +49,7 @@ with
     final as (
 
         select
-            -- Primary Key
+            -- Primary Key.
             concat(id_cnes, '.', id, '.', data_particao) as id,
             {{
                 dbt_utils.generate_surrogate_key(

--- a/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
+++ b/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
@@ -8,6 +8,11 @@
             "dado_anonimizado": "nao",
             "dado_sensivel_saude": "nao",
         },
+        partition_by={
+            "field": "data_particao",
+            "data_type": "date",
+            "granularity": "day",
+        },
         tags=['daily','vitacare_estoque']
     )
 }}
@@ -37,7 +42,7 @@ with
             _data_carga as data_carga,
             ano_particao as ano_particao,
             mes_particao as mes_particao,
-            data_particao as data_particao
+            dtacrilote as data_particao
         from source
     ),
 

--- a/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
+++ b/models/raw/prontuario_vitacare/raw_prontuario_vitacare__estoque_posicao.sql
@@ -49,7 +49,7 @@ with
     final as (
 
         select
-            -- Primary Key.
+            -- Primary Key
             concat(id_cnes, '.', id, '.', data_particao) as id,
             {{
                 dbt_utils.generate_surrogate_key(


### PR DESCRIPTION
Mexendo na tabela `rj-sms.brutos_prontuario_vitacare.estoque_posicao` percebi que n estava particionada apesar de existir o campo data_particao, então adicionei na config e considererei a data_criacao do lote como data_particao