### PR TITLE
Fix link to the administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Não esqueça de checar se você está logado no seu ambiente com a sua conta ce
 ---
 
 ## Qualquer dúvida, erro, crítica ou sugestão:
-### Basta entrar em contato com o [Administrador](@TanookiVerde) ❤️
+### Basta entrar em contato com o [Administrador](https://github.com/TanookiVerde) ❤️


### PR DESCRIPTION
The previous GitHub handler path was leading to a 404 when clicking on the link via the GH Readme:
<img width="1189" height="522" alt="Screenshot 2025-09-01 at 18 16 17" src="https://github.com/user-attachments/assets/ddfa94ee-47d4-4507-8284-750e7376bbe1" />
