### PR TITLE
Padronização de telefones de estabelecimentos em saude_dados_mestres

### DIFF
--- a/models/marts/core/dimensions/dim_estabelecimento.sql
+++ b/models/marts/core/dimensions/dim_estabelecimento.sql
@@ -34,7 +34,6 @@ final as (
       tipo, -- trocar para tipo_cnes?
       tipo_sms,
       tipo_sms_simplificado,
-      tipo_disponibilidade,
       nome_limpo,
       {{add_accents_estabelecimento('nome_limpo')}} as nome_acentuado,
       nome_sigla,
@@ -54,7 +53,7 @@ final as (
       endereco_cep,
       endereco_latitude,
       endereco_longitude,
-      telefone,
+      (select array_agg({{padronize_telefone("t")}} ignore nulls) from unnest(telefone) as t where t != '') as telefone,
       email,
       facebook,
       instagram,

--- a/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
@@ -71,7 +71,6 @@ with
             tipo_sms_simplificado,
             nome_limpo,
             nome_sigla,
-            tipo_disponibilidade,
             prontuario_tem,
             prontuario_versao,
             responsavel_sms,
@@ -205,13 +204,10 @@ with
 
             -- Atributos criados in house
             estabelecimentos_atributos.estabelecimento_sms_indicador,
-            estabelecimentos_atributos.tipo_unidade_subgeral
-            as tipo_unidade_alternativo,
-            estabelecimentos_atributos.tipo_unidade_agrupado_subgeral
-            as tipo_unidade_agrupado,
+            estabelecimentos_atributos.tipo_unidade_subgeral as tipo_unidade_alternativo,
+            estabelecimentos_atributos.tipo_unidade_agrupado_subgeral as tipo_unidade_agrupado,
             estabelecimentos_atributos.esfera_subgeral as esfera,
-            coalesce(estabelecimentos_atributos.area_programatica, aps_tb.ap)
-            as id_ap,
+            coalesce(estabelecimentos_atributos.area_programatica, aps_tb.ap) as id_ap,
             coalesce(
                 estabelecimentos_atributos.area_programatica_descr, aps_tb.ap_titulo
             )
@@ -221,7 +217,6 @@ with
             estabelecimentos_atributos.tipo_sms_simplificado,
             estabelecimentos_atributos.nome_limpo,
             estabelecimentos_atributos.nome_sigla,
-            estabelecimentos_atributos.tipo_disponibilidade,
             estabelecimentos_atributos.prontuario_tem,
             estabelecimentos_atributos.prontuario_versao,
             estabelecimentos_atributos.responsavel_sms,
@@ -324,7 +319,6 @@ with
             tipo_sms,
             tipo_sms_simplificado,
             agrupador_sms as tipo_sms_agrupado,
-            tipo_disponibilidade,
 
             -- Tipagem dos Estabelecimentos (SUBGERAL)
             tipo_unidade_alternativo,


### PR DESCRIPTION
- Padroniza números de telefones de estabelecimentos
- Remove coluna tipo_disponibilidade que não existe (mais?) na planilha auxiliar.

Obs: A coluna removida não permitia o dbt run executar sem erro.