### PR TITLE
Adicionando nova tabela de estabelecimento sem restrição de estabelecimentos municipais

### DIFF
--- a/models/marts/core/dimensions/_dimensions_schema.yml
+++ b/models/marts/core/dimensions/_dimensions_schema.yml
@@ -234,9 +234,6 @@ models:
       - name: aberto_sempre
         description: "Funcionamento do estabelecimento. Indica se fica sempre aberto / Ininterrupto: S - SIM N - NÃO"
         data_type: string
-      - name: esfera
-        description: "Classificação administrativa da esfera governamental (federal, estadual, municipal)."
-        data_type: string
       - name: turno_atendimento
         description: Descrição do Turno de Atendimento
         data_type: string

--- a/models/marts/core/dimensions/dim_estabelecimento.sql
+++ b/models/marts/core/dimensions/dim_estabelecimento.sql
@@ -60,7 +60,6 @@ final as (
       instagram,
       twitter,
       aberto_sempre,
-      esfera,
       turno_atendimento,
       diretor_clinico_cpf,
       diretor_clinico_conselho,


### PR DESCRIPTION
O modelo original **`saude_dados_mestres.estabelecimento`** era baseado na tabela histórica **`saude_cnes.estabelecimento_sus_rio_historico`**, mas aplicava três filtros:

1. **Último ano de competência** disponível.
2. **Último mês** dentro do ano mais recente.
3. **Restrição para estabelecimentos considerados municipais**: `WHERE estabelecimento_sms_indicador = 1`.

Esse último filtro limitava a tabela apenas a estabelecimentos considerados municipais pela SMS. Para atender à demanda da IplanRio, foi criado um **novo modelo de estabelecimentos** que mantém os filtros de competência (ano e mês mais recentes), mas **remove o filtro que buscava apenas estabelecimentos municipais**. Assim, a nova tabela traz estabelecimentos de **todas as esferas (municipal, estadual, federal, etc.)**