### PR TITLE
Adicionando duplicação de id na estratégia de merge para modelos Ficha A e Paciente no histórico base Vitacare

### DIFF
--- a/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_historico.sql
+++ b/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_historico.sql
@@ -106,6 +106,12 @@ with
             updated_at,
             loaded_at
         from source
+        qualify row_number() over (
+            partition by id_cnes, ut_id
+            order by
+                safe_cast(data_atualizacao_cadastro as timestamp) desc,
+                safe_cast(loaded_at as timestamp) desc
+        ) = 1
     )
 
 select *

--- a/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__paciente_historico.sql
+++ b/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__paciente_historico.sql
@@ -102,6 +102,12 @@ WITH
             ) as updated_at_rank
 
         FROM source_cadastro
+        QUALIFY row_number() OVER (
+            PARTITION BY id_cnes, ut_id
+            ORDER BY 
+                    safe_cast(data_atualizacao_cadastro as timestamp) DESC,
+                    safe_cast(loaded_at as timestamp) DESC
+        ) = 1
     )
 
 SELECT


### PR DESCRIPTION
Este PR corrige erro de conflito no `merge` dos modelos `_base_paciente_historico` e `_base_ficha_a_historico`.

### Resolução

* Adicionada deduplicação com `row_number()` + `QUALIFY`, garantindo apenas um registro por paciente (`id_cnes + ut_id`).
* Critério de desempate: `data_atualizacao_cadastro` mais recente, e `loaded_at` como segundo criterio caso dê empate na data de atualização.