### PR TITLE
Cria nova tabela de paciente para acesso da Iplan derivada de saude_historico_clinico

### DIFF
--- a/models/marts/iplanrio/paciente/_mart_iplanrio_paciente__schema.yml
+++ b/models/marts/iplanrio/paciente/_mart_iplanrio_paciente__schema.yml
@@ -1,0 +1,159 @@
+version: 2
+
+models:
+  - name: mart_iplanrio_paciente
+    description: >
+      Versão da tabela de pacientes para consumo pela IplanRio,
+      derivada de `mart_historico_clinico__paciente`
+    columns:
+      - name: cpf
+        description: CPF do paciente.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
+
+      - name: cns
+        description: ARRAY contendo os números do Cartão Nacional de Saúde (CNS) associados ao paciente.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_CNS") }}'
+
+      - name: dados
+        description: STRUCT contendo subcampos reduzidos relacionados a dados do paciente.
+        data_type: record
+
+      - name: dados.obito_indicador
+        description: Indica se o paciente é falecido ou não.
+        data_type: boolean
+        policy_tags:
+          - '{{ var("TAG_DADO_CLINICO") }}'
+
+      - name: dados.obito_data
+        description: Indica a data de falecimento do paciente.
+        data_type: timestamp
+        policy_tags:
+          - '{{ var("TAG_DADO_CLINICO") }}'
+
+      - name: dados.raca
+        description: Raça do paciente, conforme registros disponíveis.
+        data_type: string
+
+      - name: equipe_saude_familia
+        description: Array contendo as equipes de saúde da família às quais o paciente está associado.
+        data_type: record
+
+      - name: contato
+        description: STRUCT contendo informações de contato do paciente (apenas telefones e e-mails).
+        data_type: record
+
+      - name: contato.telefone
+        description: ARRAY/STRUCT contendo os números de telefone ordenados.
+        data_type: record
+        policy_tags:
+          - '{{ var("TAG_TELEFONE") }}'
+
+      - name: contato.telefone.valor
+        description: Número de telefone.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_TELEFONE") }}'
+
+      - name: contato.telefone.sistema
+        description: Sistema de origem do número de telefone.
+        data_type: string
+
+      - name: contato.telefone.rank
+        description: Ranking do telefone.
+        data_type: integer
+
+      - name: contato.email
+        description: ARRAY/STRUCT contendo os e-mails ordenados.
+        data_type: record
+        policy_tags:
+          - '{{ var("TAG_EMAIL") }}'
+
+      - name: contato.email.valor
+        description: Endereço de e-mail.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_EMAIL") }}'
+
+      - name: contato.email.sistema
+        description: Sistema de origem do e-mail.
+        data_type: string
+
+      - name: contato.email.rank
+        description: Ranking do e-mail.
+        data_type: integer
+
+      - name: endereco
+        description: Estrutura contendo informações de endereços associados ao paciente.
+        data_type: record
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.cep
+        description: Código postal (CEP) do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.tipo_logradouro
+        description: Tipo de logradouro.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.logradouro
+        description: Nome da rua/avenida/etc.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.numero
+        description: Número do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.complemento
+        description: Complemento do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.bairro
+        description: Bairro do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.cidade
+        description: Município do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.estado
+        description: Unidade federativa (estado) do endereço.
+        data_type: string
+        policy_tags:
+          - '{{ var("TAG_ENDERECO") }}'
+
+      - name: endereco.datahora_ultima_atualizacao
+        description: Data e hora da última atualização do endereço.
+        data_type: timestamp
+
+      - name: endereco.sistema
+        description: Sistema de origem do endereço.
+        data_type: string
+
+      - name: endereco.rank
+        description: Rank do endereço.
+        data_type: integer
+
+      - name: cpf_particao
+        description: Campo utilizado para particionamento de dados através do CPF. Valor representado em inteiro.
+        data_type: integer
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'

--- a/models/marts/iplanrio/paciente/mart_iplanrio_paciente.sql
+++ b/models/marts/iplanrio/paciente/mart_iplanrio_paciente.sql
@@ -1,0 +1,41 @@
+{{
+    config(
+        schema="projeto_rmi",
+        alias="paciente",
+        materialized="table",
+        tags=["hci", "paciente", "daily"],
+        partition_by={
+            "field": "cpf_particao",
+            "data_type": "int64",
+            "range": {"start": 0, "end": 100000000000, "interval": 34722222}
+        }
+    )
+}}
+
+with base as (
+    select *
+    from {{ ref("mart_historico_clinico__paciente") }}
+)
+
+select
+    cpf,
+    cns,
+
+    struct(
+        base.dados.obito_data      as obito_data,
+        base.dados.obito_indicador as obito_indicador,
+        base.dados.raca            as raca
+    ) as dados,
+
+    equipe_saude_familia,
+
+    struct(
+        base.contato.email    as email,
+        base.contato.telefone as telefone
+    ) as contato,
+
+    endereco,
+
+    cpf_particao,
+
+from base


### PR DESCRIPTION
- Fonte: saude_historico_clinico.paciente 
- Objetivo: expor apenas as colunas necessárias para uso da IplanRio
- Materialização: table, com execução diária.tag daily
- modelo de particao igual ao original
- Schema de destino: projeto_rmi

A tabela projeto_rmi.paciente, que será utilizada pela IplanRio em substituição ao acesso direto a saude_historico_clinico.paciente