### PR TITLE
BCadastro - Adiciona particionamento, clusterização e descrições de campos dos modelos

### DIFF
--- a/models/raw/bcadastro/raw_bcadastro__cnpj.sql
+++ b/models/raw/bcadastro/raw_bcadastro__cnpj.sql
@@ -8,7 +8,7 @@
           "data_type": "int64",
           "range": {"start": 0, "end": 99999999999, "interval": 2499999999975},
           },
-        tags=["daily"]
+        tags=["monthly"]
     )
 }}
 

--- a/models/raw/bcadastro/raw_bcadastro__cnpj.yml
+++ b/models/raw/bcadastro/raw_bcadastro__cnpj.yml
@@ -1,0 +1,239 @@
+version: 2
+
+models:
+  - name: raw_bcadastro__cnpj
+    description: "Este modelo contém dados cadastrais detalhados de Pessoas Jurídicas (CNPJ), incluindo informações sobre sócios, atividades econômicas e situação cadastral."
+    columns:
+      
+      - name: cnpj 
+        description: "Informações do Cadastro Nacional da Pessoa Jurídica (CNPJ)."
+      - name: cnpj.cnpj
+        description: "Número do Cadastro Nacional da Pessoa Jurídica (CNPJ) da empresa."
+
+      - name: cnpj.razao_social
+        description: "Razão Social da empresa, conforme registrada oficialmente."
+
+      - name: cnpj.nome_fantasia
+        description: "Nome fantasia ou nome comercial da empresa."
+
+      - name: cnpj.capital_social
+        description: "Valor do capital social da empresa declarado em moeda local."
+
+      - name: cnpj.cnae_fiscal
+        description: "Código da Classificação Nacional de Atividades Econômicas (CNAE) principal da empresa."
+
+      - name: cnpj.cnae_secundarias
+        description: "Lista de códigos CNAE secundários associados à empresa."
+
+      - name: cnpj.nire
+        description: "Número de Identificação do Registro de Empresas (NIRE)."
+
+      - name: cnpj.natureza_juridica
+        description: "Informações sobre a natureza jurídica da empresa."
+
+      - name: cnpj.natureza_juridica.id
+        description: "Código da natureza jurídica da empresa."
+
+      - name: cnpj.natureza_juridica.descricao
+        description: "Descrição da natureza jurídica (ex: Sociedade Empresária Limitada)."
+
+      - name: cnpj.porte
+        description: "Informações sobre o porte da empresa."
+
+      - name: cnpj.porte.id
+        description: "Código que identifica o porte da empresa."
+
+      - name: cnpj.porte.descricao
+        description: "Descrição do porte da empresa."
+
+      - name: cnpj.matriz_filial
+        description: "Indicação se o estabelecimento é matriz ou filial."
+
+      - name: cnpj.matriz_filial.id
+        description: "Código identificador se o estabelecimento é matriz ou filial."
+
+      - name: cnpj.matriz_filial.descricao
+        description: "Descrição se o estabelecimento é 'Matriz' ou 'Filial'."
+
+      - name: cnpj.orgao_registro
+        description: "Órgão de registro da empresa."
+
+      - name: cnpj.orgao_registro.id
+        description: "Código identificador do órgão de registro."
+      
+      - name: cnpj.orgao_registro.descricao
+        description: "Descrição do órgão de registro."
+
+      - name: cnpj.inicio_atividade_data
+        description: "Data de início das atividades da empresa."
+
+      - name: cnpj.situacao_cadastral
+        description: "Informações sobre a situação cadastral da empresa."
+
+      - name: cnpj.situacao_cadastral.id
+        description: "Código da situação cadastral (ex: 02 - Ativa)."
+
+      - name: cnpj.situacao_cadastral.descricao
+        description: "Descrição da situação cadastral da empresa (ex: Ativa, Baixada)."
+
+      - name: cnpj.situacao_cadastral.data
+        description: "Data em que a situação cadastral foi alterada pela última vez."
+
+      - name: cnpj_situacao_cadastral_motivo_id
+        description: "Código do motivo da alteração da situação cadastral."
+
+      - name: cnpj.situacao_cadastral.motivo.descricao
+        description: "Descrição do motivo da alteração da situação cadastral."
+
+      - name: cnpj.situacao_especial
+        description: "Informações sobre qualquer situação especial da empresa."
+
+      - name: cnpj.situacao_especial.descricao
+        description: "Descrição de qualquer situação especial da empresa (ex: Recuperação Judicial)."
+
+      - name: cnpj.situacao_especial.data
+        description: "Data de início da situação especial."
+
+      - name: cnpj.ente_federativo
+        description: 'Informações sobre o ente federativo onde a empresa está registrada.'
+
+      - name: cnpj.ente_federativo.id
+        description: "Código do ente federativo."
+
+      - name: cnpj.ente_federativo.descricao  
+        description: "Descrição do ente federativo (ex: Município, Estado)."
+
+      - name: cnpj.telefone
+        description: "Dados de telefone de contato da empresa."
+
+      - name: cnpj.telefone.ddd 
+        description: "Código de Discagem Direta (DDD) do telefone de contato."
+
+      - name: cnpj.telefone.numero 
+        description: "Número do telefone de contato da empresa."  
+
+      - name: cnpj.contato.email
+        description: "Endereço de e-mail de contato da empresa."
+
+      - name: cnpj.endereco.cep
+        description: "Código de Endereçamento Postal (CEP) do endereço da empresa."
+
+      - name: cnpj.endereco.id_pais
+        description: "Identificador único do país onde a empresa está localizada." 
+
+      - name: cnpj.endereco.uf
+        description: "Unidade Federativa (Estado) onde a empresa está localizada."
+
+      - name: cnpj.endereco.id_municipio
+        description: "Código do IBGE para o município de localização da empresa."
+
+      - name: cnpj.endereco.municipio_nome
+        description: "Nome do município de localização da empresa."
+
+      - name: cnpj.endereco.municipio_exterior_nome
+        description: "-"
+
+      - name: cnpj.endereco.bairro
+        description: "Bairro do endereço da empresa."
+
+      - name: cnpj.endereco.tipo_logradouro
+        description: "Tipo de logradouro do endereço da empresa."
+
+      - name: cnpj.endereco.logradouro
+        description: "Nome do logradouro (rua, avenida) do endereço da empresa."
+
+      - name: cnpj.endereco.numero
+        description: "Número do imóvel no endereço da empresa."
+
+      - name: cnpj.endereco.complemento
+        description: "Complemento do endereço (sala, andar, etc.)."
+
+      - name: cnpj.contador
+        description: "Informações sobre o contador responsável pela empresa."
+
+      - name: cnpj.contador.pf
+        description: "Informações da pessoa física do contador."
+      
+      - name: cnpj.contador.pf.tipo_crc
+        description: "Carece de descrição"
+
+      - name: cnpj.contador.pf.classificacao_crc
+        description: "Carece de descrição"
+
+      - name: cnpj.contador.pf.sequencial_crc
+        description: "Carece de descrição"  
+
+      - name: cnpj.contador.pf.id
+        description: "Carece de descrição"
+
+      - name: cnpj.contador.pj
+        description: "Informações da pessoa jurídica do contador."
+
+      - name: cnpj.contador.pj.tipo_crc
+        description: "Carece de descrição"
+
+      - name: cnpj.contador.pj.classificacao_crc
+        description: "Carece de descrição"
+
+      - name: cnpj.contador.pj.sequencial_crc
+        description: "Carece de descrição"  
+
+      - name: cnpj.contador.pj.id
+        description: "Carece de descrição"
+
+      - name: cnpj.responsavel
+        description: "Informações sobre o responsável legal da empresa."
+
+      - name: cnpj.responsavel.cpf
+        description: "CPF da pessoa física responsável pela empresa perante o CNPJ."
+
+      - name: cnpj.responsavel.qualificacao_descricao
+        description: "Descrição da qualificação do responsável (ex: Sócio-Administrador)."
+
+      - name: cnpj.socios_quantidade
+        description: "Número total de sócios no quadro societário da empresa."
+
+      - name: cnpj.tipos_unidade
+        description: "Tipo de unidade do estabelecimento."
+
+      - name: cnpj.socios.cpf_socio
+        description: "CPF do sócio (um por linha após UNNEST)."
+
+      - name: cnpj.socios.cnpj_socio
+        description: "CNPJ do sócio, caso seja uma pessoa jurídica (um por linha após UNNEST)."
+
+      - name: cnpj.socios.qualificacao_socio
+        description: "Descrição da qualificação do sócio (ex: Sócio, Administrador)."
+      
+      - name: cnpj.socios.tipo
+        description: "Tipo de sócio (Pessoa Física, Pessoa Jurídica, Sócio Estrangeiro)."
+      
+      - name: cnpj_particao
+        description: "Campo técnico para particionamento da tabela, visando otimização de consultas."
+
+      - name: razao_social
+        description: "Razão Social da empresa, conforme registrada oficialmente."
+
+      - name: nome_fantasia
+        description: "Nome fantasia ou nome comercial da empresa."
+
+      - name: cnae_fiscal
+        description: "Código da Classificação Nacional de Atividades Econômicas (CNAE) principal da empresa."
+
+      - name: cnae_secundarias
+        description: "Lista de códigos CNAE secundários associados à empresa."
+
+      - name: inicio_atividade_data
+        description: "Data de início das atividades da empresa."
+
+      - name: situacao_cadastral
+        description: "Descrição da situação cadastral da empresa (ex: Ativa, Baixada)."
+
+      - name: cpf
+        description: "CPF de um responsável ou contato associado ao registro da empresa."
+
+      - name: endereco
+        description: "Informações do endereço da empresa."
+
+      - name: situacao
+        description: "Campo de status simplificado do registro."

--- a/models/raw/bcadastro/raw_bcadastro__cpf.sql
+++ b/models/raw/bcadastro/raw_bcadastro__cpf.sql
@@ -1,8 +1,19 @@
 {{
     config(
         alias="cpf",
-        materialized="table"
+        materialized="table",
+        schema="brutos_bcadastro",
+        cluster_by="situacao_cadastral_tipo",
+        partition_by={
+            "field": "cpf_particao",
+            "data_type": "int64",
+            "range": {"start": 0, "end": 100000000000, "interval": 34722222},
+        },
+
     )
 }}
 
-select * from {{ source("brutos_bcadastro", 'cpf') }}
+select 
+    * except(airbyte, metadados), 
+    metadados.ano_exercicio 
+    from {{ source("brutos_bcadastro", 'cpf') }}

--- a/models/raw/bcadastro/raw_bcadastro__cpf.yml
+++ b/models/raw/bcadastro/raw_bcadastro__cpf.yml
@@ -1,0 +1,138 @@
+version: 2
+
+models:
+  - name: raw_bcadastro__cpf
+    description: "Este modelo contém informações cadastrais detalhadas de pessoas físicas, enriquecidas com dados de endereço, contato e ocupação."
+    columns:
+      - name: cpf
+        description: "Número do Cadastro de Pessoas Físicas (CPF) do titular."
+        data_tests:
+          - not_null
+      - name: nome
+        description: "Nome de registro completo do titular."
+
+      - name: nome_social
+        description: "Nome social do titular, se aplicável."
+
+      - name: mae_nome
+        description: "Nome completo da mãe do titular."
+
+      - name: nascimento_data
+        description: "Data de nascimento do titular."
+
+      - name: inscricao_data
+        description: "Data em que o CPF foi inscrito."
+
+      - name: atualizacao_data
+        description: "Data da última atualização realizada no cadastro do titular."
+
+      - name: situacao_cadastral_tipo
+        description: "Descrição da situação cadastral do CPF (ex: Regular, Titular Falecido)."
+
+      - name: sexo
+        description: "Sexo biológico registrado do titular."
+
+      - name: obito_ano
+        description: "Ano de óbito do titular, caso a situação cadastral seja 'Titular Falecido'."
+
+      - name: estrangeiro_indicador
+        description: "Indicador booleano (TRUE/FALSE) que informa se o titular é estrangeiro."
+
+      - name: residente_exterior_indicador
+        description: "Indicador booleano (TRUE/FALSE) que informa se o titular reside no exterior."
+
+      - name: contato 
+        description: "Informações de contato do titular, incluindo telefone e e-mail."
+
+      - name: contato.telefone
+        description: "Dados de telefone do titular."
+
+      - name: contato.telefone.ddi
+        description: "Código de Discagem Direta Internacional (DDI) do telefone de contato."
+      
+      - name: contato.telefone.ddd
+        description: "Código de Discagem Direta (DDD) do telefone de contato."
+
+      - name: contato.telefone.numero
+        description: "Número do telefone de contato."
+
+      - name: contato.email
+        description: "Endereço de e-mail do titular."
+      
+      - name: endereco
+        description: "Informações de endereço do titular, incluindo logradouro, número, complemento, bairro, município, UF e CEP."
+
+      - name: endereco.cep
+        description: "Código de Endereçamento Postal (CEP) do endereço de residência."
+
+      - name: endereco.id_pais
+        description: "Identificador único do país de residência."
+
+      - name: endereco.pais
+        description: "Nome do país de residência."
+
+      - name: endereco.uf
+        description: "Unidade Federativa (Estado) de residência."
+
+      - name: endereco.id_municipio
+        description: "Identificador único do município de residência."
+
+      - name: endereco.municipio
+        description: "Nome do município de residência."
+
+      - name: endereco.bairro
+        description: "Bairro de residência."
+
+      - name: endereco.tipo_logradouro
+        description: "Tipo do logradouro do endereço (ex: Rua, Avenida, Praça)."
+
+      - name: endereco.logradouro
+        description: "Nome do logradouro do endereço."
+
+      - name: endereco.numero
+        description: "Número do imóvel na residência."
+
+      - name: endereco.complemento
+        description: "Complemento do endereço residencial (ex: apartamento, bloco)."
+
+      - name: nascimento_local
+        description: "Informações sobre o local de nascimento do titular."
+
+      - name: nascimento_local.id_pais
+        description: "Identificador do país de nascimento do titular."
+
+      - name: nascimento_local.pais
+        description: "Nome do país de nascimento do titular."
+
+      - name: nascimento_local.id_municipio
+        description: "Identificador do município de nascimento do titular."
+
+      - name: nascimento_local.municipio
+        description: "Nome do município de nascimento do titular."
+
+      - name: nascimento_local.uf
+        description: "Unidade Federativa (Estado) de nascimento do titular."
+
+      - name: ocupacao
+        description: "Informações sobre a ocupação profissional do titular."
+
+      - name: ocupacao.id 
+        description: "Identificador da ocupação profissional do titular."
+
+      - name: ocupacao.nome
+        description: "Nome da ocupação profissional do titular."
+
+      - name: ocupacao.id_natureza
+        description: "Identificador da natureza da ocupação profissional do titular." 
+      
+      - name: ocupacao.ua
+
+      - name: metadados
+        description: "Metadados do registro, incluindo informações sobre a fonte dos dados e datas de importação."
+
+      - name: ano_exercicio
+        description: "Ano de exercício do cadastro."
+
+      - name: cpf_particao
+        description: "Número utilizado para particionar a tabela, derivado dos três primeiros dígitos do CPF."
+        data_type: int64


### PR DESCRIPTION
Adiciona particionamento e clusterização na tabela `brutos_bcadastro__cpf`

Sobre as descrições de campos, ainda há campos sem descrição, pois carece de detalhes sobre e/ou é um campo repetido. 

Foram executados os seguintes comandos para os modelos alterados: `dbt run`, `dbt test` e `dbt build`