### PR TITLE
Altera permissões de acesso no HCI para todos os profissionais do grupo de dentistas

### DIFF
--- a/models/intermediate/dit/historico_clinico/acessos/int_acessos__automatico.sql
+++ b/models/intermediate/dit/historico_clinico/acessos/int_acessos__automatico.sql
@@ -166,13 +166,13 @@ with
                         then 'full_permission'
                         when unidade_tipo in ('UPA','HOSPITAL', 'CER', 'CE','MATERNIDADE','CENTRAL DE REGULACAO','CASS')
                         then 'full_permission'
-                        when (unidade_tipo in ('CGS','CAPS') and funcao_grupo = 'MEDICOS' )
+                        when unidade_tipo in ('CGS','CAPS') and funcao_grupo in ('MEDICOS','DENTISTAS')
                         then 'full_permission'
-                        when (unidade_tipo in ('CGS','CAPS') and funcao_grupo != 'MEDICOS' )
+                        when unidade_tipo in ('CGS','CAPS') and funcao_grupo not in ('MEDICOS','DENTISTAS')
                         then 'only_from_same_ap'
-                        when unidade_tipo in ('CMS','POLICLINICA','CF','CMR','CSE') and funcao_grupo = 'MEDICOS' 
+                        when unidade_tipo in ('CMS','POLICLINICA','CF','CMR','CSE') and funcao_grupo in ('MEDICOS','DENTISTAS')
                         then 'full_permission'
-                        when unidade_tipo in ('CMS','POLICLINICA','CF','CMR','CSE') and funcao_grupo != 'MEDICOS' 
+                        when unidade_tipo in ('CMS','POLICLINICA','CF','CMR','CSE') and funcao_grupo not in ('MEDICOS','DENTISTAS')
                         then 'only_from_same_cnes'
                         else null
                     end as nivel_acesso,

--- a/models/marts/core/dimensions/dim_profissional_saude.sql
+++ b/models/marts/core/dimensions/dim_profissional_saude.sql
@@ -63,7 +63,7 @@ with
             case 
                 when regexp_contains(lower(cbo),'^medic')
                     then 'MÉDICOS'
-                when regexp_contains(lower(cbo),'^cirurgiao[ |-|]dentista')
+                when regexp_contains(lower(cbo), r'^cirurgiao[- ]?dentista')
                     then 'DENTISTAS'
                 when regexp_contains(lower(cbo),'psic')
                     then 'PSICÓLOGOS'  


### PR DESCRIPTION
Atualmente, a categoria de DENTISTAS está visualizando apenas os dados referentes ao mesmo CNES da unidade em que atua. Essa lógica restringe o acesso dos dentistas apenas aos pacientes daquela unidade específica. Com isso, foi necessário alterar a regra de acesso no HCI para que os dentistas tenham acesso compleeto às informações de pacientes de todo o território, e não apenas da sua unidade.

Alterações:

- CBOS contemplados: basicamente apenas Cirurgiões-Dentistas terão acesso. Funções de nível técnico, auxiliares e administrativos não serão contempladas (ex.: técnicos em saúde bucal, auxiliares de consultório dentário, recepcionistas).
- Critério de seleção: em vez de filtrar explicitamente pelos números de CBO, foi utilizada a regex já existente para “cirurgião-dentista”, o que garante a contemplação de todos os CBOs relevantes sem necessidade de lista manua de cbos.
- Ajustes no modelo acessos_automatico: inclusão da categoria DENTISTAS nas mesmas regras de acesso já aplicadas a médicos, garantindo consistência e simplificação da manutenção futura.
- Ajusteste no regex de classificação de CBOS na tabela equipe_profissional_saude que estava categorizando 'Cirurgião-dentista da estratégia de saúde da família' incorretamente como OUTROS PROFISSIONAIS em vez de DENTISTAS