### PR TITLE
Adiciona tabelas que contêm respostas do chatbot e resposta_disparo do projeto Cegonha, disponibilizado pela Iplan

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -93,6 +93,13 @@ models:
     raw:
       +materialized: table
       +tags: "raw"
+      iplan:
+        +schema: brutos_iplanrio
+        +tags: "daily"
+        +labels:
+          dado_publico: nao
+          dado_pessoal: sim
+          dado_sensivel: sim
       aplicacao_hci:
         +schema: brutos_aplicacao_hci
         +tags: "daily"

--- a/models/raw/iplanrio/_iplanrio_sources.yml
+++ b/models/raw/iplanrio/_iplanrio_sources.yml
@@ -6,3 +6,15 @@ sources:
     schema: brutos_iplanrio
     tables:
       - name: registro_municipal_integrado
+
+  - name: iplanrio_rmi_conversas
+    database: rj-crm-registry
+    schema: rmi_conversas
+    tables:
+      - name: chatbot
+
+  - name: iplanrio_intermediario_rmi_conversas
+    database: rj-crm-registry
+    schema: intermediario_rmi_conversas
+    tables:
+      - name: resposta_disparo

--- a/models/raw/iplanrio/_raw_iplanrio__chatbot_schema.yml
+++ b/models/raw/iplanrio/_raw_iplanrio__chatbot_schema.yml
@@ -1,0 +1,259 @@
+version: 2
+
+models:
+  - name: raw_iplanrio__chatbot
+    description: >
+      Tabela que contem os registros da tabela
+      de interações do chatbot do Projeto Cegonha Digital disponibilizado Iplan. Armazena o histórico completo das interações
+      entre cidadão e WhatsApp, incluindo dados do contato, informações do disparo
+      de HSM, mensagens trocadas, uso de URA, erros de fluxo, métricas da sessão
+      e indicadores de entrega, leitura e resposta.
+    columns:
+      - name: id_interacao
+        description: "Chave primária única da interação, gerada como um hash MD5."
+
+      - name: id_sessao
+        description: "ID da sessão de conversa (reply ID do Wetalkie). Pode ser nulo se a interação foi um disparo que não gerou conversa."
+
+      - name: id_externo
+        description: "ID externo associado ao contato, vindo da URA."
+
+      - name: protocolo
+        description: "Número de protocolo associado ao atendimento receptivo."
+
+      - name: inicio_datahora
+        description: "Data e hora de início da interação. Para disparos, é a criação do envio; para receptivo, é o início da URA. Fuso horário America/Sao_Paulo."
+
+      - name: fim_datahora
+        description: "Data e hora do último evento registrado na interação. Fuso horário America/Sao_Paulo."
+
+      - name: contato
+        description: "Estrutura com informações consolidadas do contato."
+
+      - name: contato.id_contato
+        description: "ID do contato na plataforma Wetalkie."
+
+      - name: contato.contato_telefone
+        description: "Número de telefone do contato."
+
+      - name: contato.contato_nome
+        description: "Nome do contato."
+
+      - name: contato.cpf
+        description: "CPF do contato (quando disponível)."
+
+      - name: contato.data_optin
+        description: "Data de opt-in do contato (quando disponível)."
+
+      - name: contato.data_optout
+        description: "Data de opt-out do contato (quando disponível)."
+
+      - name: hsm
+        description: "Estrutura com informações do disparo de HSM (mensagem ativa)."
+
+      - name: hsm.indicador
+        description: "Indicador (true/false) se a interação foi iniciada por um HSM."
+
+      - name: hsm.indicador_falha
+        description: "Indicador (true/false) se o envio do HSM falhou."
+
+      - name: hsm.id_hsm
+        description: "ID do template de mensagem (HSM) enviado."
+
+      - name: hsm.id_disparo
+        description: "ID único do disparo."
+
+      - name: hsm.status_disparo
+        description: "Descrição textual do status do disparo (ex: delivered, read, failed)."
+
+      - name: hsm.nome_hsm
+        description: ""
+
+      - name: hsm.nome_campanha
+        description: "Nome da campanha associada ao disparo."
+
+      - name: hsm.categoria_hsm
+        description: "Categoria do template de mensagem (HSM)."
+
+      - name: hsm.orgao_responsavel
+        description: "Órgão responsável pela campanha."
+
+      - name: hsm.ambiente
+        description: "Ambiente de onde o disparo foi feito."
+
+      - name: hsm.criacao_envio_datahora
+        description: "Data e hora de criação do envio. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.envio_datahora
+        description: "Data e hora do envio. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.entrega_datahora
+        description: "Data e hora da entrega. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.leitura_datahora
+        description: "Data e hora da leitura. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.resposta_datahora
+        description: "Data e hora da resposta. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.falha_datahora
+        description: "Data e hora da falha. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.descricao_falha
+        description: "Descrição da falha do HSM, caso tenha ocorrido."
+
+      - name: hsm.inicio_datahora_ativo
+        description: "Alias para criacao_envio_datahora. Fuso horário America/Sao_Paulo."
+
+      - name: hsm.fim_datahora_ativo
+        description: "Data e hora do último evento do HSM. Fuso horário America/Sao_Paulo."
+
+      - name: erro_fluxo
+        description: "Estrutura com informações sobre erros identificados no fluxo da conversa."
+
+      - name: erro_fluxo.indicador
+        description: "Indicador (true/false) se algum erro foi detectado na sessão."
+
+      - name: erro_fluxo.tipo_erro
+        description: "Array com os tipos de erros detectados (ex: fluxo_travado, loop_ura)."
+
+      - name: mensagens
+        description: "Array com o histórico de mensagens da conversa (quando aplicável)."
+
+      - name: mensagens.data
+        description: ""
+
+      - name: mensagens.anexos
+        description: ""
+
+      - name: mensagens.hsm
+        description: ""
+
+      - name: mensagens.id
+        description: ""
+
+      - name: mensagens.fonte
+        description: ""
+
+      - name: mensagens.midia
+        description: ""
+
+      - name: mensagens.midia.arquivo
+        description: ""
+
+      - name: mensagens.midia.nome
+        description: ""
+
+      - name: mensagens.midia.tipo_conteudo
+        description: ""
+
+      - name: mensagens.texto
+        description: ""
+
+      - name: mensagens.tipo
+        description: ""
+
+      - name: mensagens.titulo
+        description: ""
+
+      - name: mensagens.operador
+        description: ""
+
+      - name: mensagens.passo_ura
+        description: ""
+
+      - name: mensagens.passo_ura.nome
+        description: ""
+
+      - name: mensagens.passo_ura.id
+        description: ""
+
+      - name: busca
+        description: "Estrutura com informações sobre a funcionalidade de busca dentro do chatbot."
+
+      - name: busca.indicador
+        description: "Indicador (true/false) se a sessão utilizou a funcionalidade de busca."
+
+      - name: busca.feedback
+        description: "Estrutura com o feedback do usuário sobre a busca."
+
+      - name: busca.feedback.pergunta
+        description: ""
+
+      - name: busca.feedback.resposta
+        description: ""
+
+      - name: busca.feedback.resposta_negativa_complemento
+        description: ""
+
+      - name: ura
+        description: "Estrutura com informações da URA (atendimento receptivo)."
+
+      - name: ura.indicador
+        description: "Indicador (true/false) se a interação passou pela URA."
+
+      - name: ura.id
+        description: "ID da URA."
+
+      - name: ura.nome
+        description: "Nome da URA."
+
+      - name: ura.inicio_datahora_receptivo
+        description: "Data e hora de início da URA. Fuso horário America/Sao_Paulo."
+
+      - name: ura.fim_datahora_receptivo
+        description: "Data e hora de fim da URA. Fuso horário America/Sao_Paulo."
+
+      - name: estatisticas
+        description: "Estrutura com métricas e estatísticas calculadas da sessão."
+
+      - name: estatisticas.total_mensagens
+        description: "Número total de mensagens na conversa."
+
+      - name: estatisticas.total_mensagens_contato
+        description: "Número de mensagens enviadas pelo contato."
+
+      - name: estatisticas.total_mensagens_busca
+        description: "Número de mensagens relacionadas à funcionalidade de busca."
+
+      - name: estatisticas.duracao_sessao_seg
+        description: "Duração total da sessão em segundos."
+
+      - name: estatisticas.duracao_interacao_seg
+        description: "Duração da interação do cliente em segundos."
+
+      - name: estatisticas.duracao_ura_seg
+        description: "Duração da URA em segundos."
+
+      - name: estatisticas.tempo_medio_resposta_cliente_seg
+        description: "Tempo médio de resposta do cliente em segundos."
+
+      - name: operador
+        description: "Nome do operador que atendeu (se aplicável)."
+
+      - name: tabulacao
+        description: "Estrutura com informações de tabulação do atendimento."
+
+      - name: tabulacao.nome
+        description: ""
+
+      - name: tabulacao.id
+        description: ""
+
+      - name: foi_entregue
+        description: "Indicador (true/false) se a mensagem HSM foi entregue."
+
+      - name: foi_lida
+        description: "Indicador (true/false) se a mensagem HSM foi lida."
+
+      - name: foi_respondida
+        description: "Indicador (true/false) se a mensagem HSM foi respondida."
+
+      - name: gerou_conversa
+        description: "Indicador (true/false) se a interação gerou uma sessão de conversa na URA."
+
+      - name: data_particao
+        description: "Data da partição da tabela, baseada na data de início da interação."
+
+      - name: data_processamento
+        description: "Data e hora em que o registro foi processado pelo dbt. Fuso horário America/Sao_Paulo."

--- a/models/raw/iplanrio/_raw_iplanrio__resposta_disparo_schema.yml
+++ b/models/raw/iplanrio/_raw_iplanrio__resposta_disparo_schema.yml
@@ -1,0 +1,109 @@
+version: 2
+
+models:
+  - name: raw_iplanrio__resposta_disparo
+    description: >
+      Tabela com os registros de respostas a disparos do Projeto Cegonha Digital
+      disponibilizada pela Iplan. Cada linha representa uma mensagem associada a
+      uma interação considerada como resposta a um disparo, contendo informações
+      sobre o HSM enviado, o status do disparo, a identificação do contato e o
+      conteúdo das mensagens relacionadas à resposta.
+    columns:
+      - name: id_conta
+        description: "Identificador da conta/plataforma de envio à qual o disparo está associado."
+
+      - name: id_hsm
+        description: "Identificador do template de mensagem ativa (HSM) enviado."
+
+      - name: id_disparo
+        description: "Identificador único do disparo."
+
+      - name: id_externo
+        description: "Identificador externo associado ao contato ou cidadão no sistema de origem."
+
+      - name: id_target
+        description: "Identificador do alvo/destinatário do disparo na plataforma."
+
+      - name: contato_telefone
+        description: "Número de telefone do contato associado ao disparo."
+
+      - name: nome_hsm
+        description: "Nome do template de mensagem ativa (HSM) enviado."
+
+      - name: nome_campanha
+        description: "Nome da campanha associada ao disparo."
+
+      - name: orgao_responsavel
+        description: "Órgão responsável pela campanha ou disparo."
+
+      - name: categoria_hsm
+        description: "Categoria do template de mensagem ativa."
+
+      - name: ambiente
+        description: "Ambiente em que o disparo foi realizado, como prod."
+
+      - name: criacao_envio_datahora
+        description: "Data e hora de criação do envio do disparo."
+
+      - name: envio_datahora
+        description: "Data e hora em que o disparo foi enviado."
+
+      - name: entrega_datahora
+        description: "Data e hora em que o disparo foi entregue ao destinatário."
+
+      - name: leitura_datahora
+        description: "Data e hora em que o disparo foi lido pelo destinatário."
+
+      - name: falha_datahora
+        description: "Data e hora em que foi registrada falha no disparo, quando aplicável."
+
+      - name: resposta_datahora
+        description: "Data e hora da resposta associada ao disparo, quando identificada pela regra da tabela."
+
+      - name: fim_datahora
+        description: "Data e hora do último evento considerado na interação/resposta associada ao disparo."
+
+      - name: datarelay_datahora
+        description: "Data e hora em que o registro foi encaminhado ou atualizado na camada de relay/processamento."
+
+      - name: descricao_falha
+        description: "Descrição da falha do disparo, quando houver."
+
+      - name: indicador_falha
+        description: "Indicador se houve falha no disparo."
+
+      - name: id_status_disparo
+        description: "Identificador numérico do status do disparo."
+
+      - name: status_disparo
+        description: "Descrição textual do status do disparo, como delivered ou read."
+
+      - name: ano_particao
+        description: "Ano de partição lógica do registro."
+
+      - name: mes_particao
+        description: "Mês de partição lógica do registro."
+
+      - name: id_sessao
+        description: "Identificador da sessão de conversa associada à resposta ao disparo."
+
+      - name: datahora_resposta
+        description: "Data e hora da mensagem registrada como parte da resposta ou do fluxo relacionado ao disparo."
+
+      - name: mensagem_resposta
+        description: "Conteúdo textual da mensagem associada à resposta ou ao fluxo subsequente do disparo."
+
+      - name: id_mensagem_resposta
+        description: "Identificador da mensagem registrada como resposta ou mensagem relacionada ao disparo."
+
+      - name: mensagem_fonte
+        description: "Origem da mensagem registrada, como CUSTOMER, FLOW, SYSTEM ou URA."
+
+      - name: id_contato
+        description: "Identificador do contato na plataforma de mensageria."
+
+      - name: horas_para_responder
+        description: "Quantidade de horas entre o envio do disparo e a resposta considerada pela regra da tabela."
+
+      - name: data_particao
+        description: "Data de partição do registro."

--- a/models/raw/iplanrio/raw_iplanrio__chatbot.sql
+++ b/models/raw/iplanrio/raw_iplanrio__chatbot.sql
@@ -1,8 +1,9 @@
 {{
     config(
-        alias="chatbot",
         materialized="table",
-        schema="brutos_iplanrio"
+        schema="brutos_iplanrio",
+        alias="chatbot",
+        tags=['daily']
     )
 }}
 

--- a/models/raw/iplanrio/raw_iplanrio__chatbot.sql
+++ b/models/raw/iplanrio/raw_iplanrio__chatbot.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        alias="chatbot",
+        materialized="table",
+        schema="brutos_iplanrio"
+    )
+}}
+
+select *
+from {{ source('iplanrio_rmi_conversas', 'chatbot') }}

--- a/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
+++ b/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        alias="resposta_disparo",
+        materialized="table",
+        schema="brutos_iplanrio"
+    )
+}}
+
+select *
+from {{ source('iplanrio_intermediario_rmi_conversas', 'resposta_disparo') }}

--- a/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
+++ b/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
@@ -1,8 +1,9 @@
 {{
     config(
-        alias="resposta_disparo",
         materialized="table",
-        schema="brutos_iplanrio"
+        schema="brutos_iplanrio",
+        alias="resposta_disparo",
+        tags=['daily']
     )
 }}
 


### PR DESCRIPTION
Adiciona os sources e os modelos raw das tabelas chatbot e resposta_disparo disponibilizadas pela Iplan após disparos do projeto cegonha digital, materializando-as no schema brutos_iplanrio e preservando a estrutura original das tabelas para uso posterior nas camadas analíticas do projeto (paineis de monitoramento)