### PR TITLE
Adiciona filtro de ingestão para incluir apenas mensagens de disparo de puérperas

### DIFF
--- a/models/raw/iplanrio/raw_iplanrio__chatbot.sql
+++ b/models/raw/iplanrio/raw_iplanrio__chatbot.sql
@@ -9,4 +9,4 @@
 
 select *
 from {{ source('iplanrio_rmi_conversas', 'chatbot') }}
-where lower(hsm.nome_campanha) = 'sms-puerpera'
+where lower(hsm.nome_hsm) like '%puerpera%'

--- a/models/raw/iplanrio/raw_iplanrio__chatbot.sql
+++ b/models/raw/iplanrio/raw_iplanrio__chatbot.sql
@@ -9,3 +9,4 @@
 
 select *
 from {{ source('iplanrio_rmi_conversas', 'chatbot') }}
+where lower(hsm.nome_campanha) = 'sms-puerpera'

--- a/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
+++ b/models/raw/iplanrio/raw_iplanrio__resposta_disparo.sql
@@ -9,3 +9,4 @@
 
 select *
 from {{ source('iplanrio_intermediario_rmi_conversas', 'resposta_disparo') }}
+where lower(nome_hsm) like '%puerpera%'


### PR DESCRIPTION
As tabelas de disparo do projeto Iplan continham registros de diferentes campanhas e órgãos, sem restrição aos envios de puérperas relacionados à SMS. Isso fazia com que a ingestão para o datalake da SMS pudesse trazer dados fora do escopo esperado do projeto Cegonha.

Resolução: foi aplicado um filtro nas tabelas ingeridas para considerar apenas os registros de mensagens de disparo de puérperas vinculadas aos projetos da SMS, excluindo campanhas de outros órgãos e fora do escopo do Projeto Cegonha.