### PR TITLE
[monitora cancer] refactor: patient data handling and add policy tags

### DIFF
--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_bcadastro.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_bcadastro.sql
@@ -9,25 +9,17 @@ with pacientes as (
         nome_social as paciente_nome_social,
         upper(sexo) as paciente_sexo,
 
-        /*
-        endereco.complemento as paciente_complemento_residencia,
-        endereco.numero as paciente_numero_residencia,
-        endereco.cep as paciente_cep_residencia,
-        endereco.logradouro as paciente_endereco_residencia,
-        endereco.tipo_logradouro as paciente_tp_logradouro_residencia,
-        endereco.bairro as paciente_bairro_residencia,
-        endereco.municipio as paciente_municipio_residencia,
-        endereco.uf as paciente_uf_residencia,
-        */
-
         concat(
             coalesce(contato.telefone.ddi, ''),
             coalesce(contato.telefone.ddd, ''),
             coalesce(contato.telefone.numero, '')
         ) as paciente_telefone,
-        --contato.email as paciente_email,      
     
-        safe_cast(obito_ano as int) as paciente_obito_ano
+        safe_cast(obito_ano as int) as paciente_obito_ano,
+
+        -- bcadastro (Receita Federal) é um snapshot sem granularidade por paciente de atualização.
+        -- mantemos null no desempate, a prioridade do bcadastro vem da ordem fixa de sistemas.
+        cast(null as timestamp) as data_atualizacao
 
     from {{ source("brutos_bcadastro_sms", "cpf") }}
     where
@@ -35,5 +27,4 @@ with pacientes as (
         or endereco.municipio = "Rio de Janeiro"
 )
 
-select * from pacientes 
--- paciente_sexo: feminino, masculino
+select * from pacientes

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_fibromialgia.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_fibromialgia.sql
@@ -7,7 +7,10 @@ with pacientes as (
 
     estabs.nome_acentuado as clinica_sf,
     estabs.area_programatica as clinica_sf_ap,
-    estabs.telefone[SAFE_OFFSET(0)] as clinica_sf_telefone
+    estabs.telefone[SAFE_OFFSET(0)] as clinica_sf_telefone,
+
+    -- proxy de atualização cadastral: data da solicitação mais recente no relatório Fibromialgia.
+    safe_cast(solicitacaodatahora as timestamp) as data_atualizacao
 
   from {{ ref("raw_centralderegulacao_mysql__fibromialgia_relatorio") }}
   left join {{ ref("dim_estabelecimento") }} as estabs
@@ -15,4 +18,8 @@ with pacientes as (
   where date(solicitacaodatahora) >= date '2024-01-01'
 )
 
-select distinct * from pacientes
+select * from pacientes
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_hci.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_hci.sql
@@ -10,7 +10,6 @@ with pacientes as (
             upper(dados.nome_social) as paciente_nome_social,
             upper(dados.genero) as paciente_sexo,
             upper(dados.raca) as paciente_racacor,
-            --upper(dados.pai_nome) as paciente_nome_pai,
 
             extract(year from dados.obito_data) as paciente_obito_ano,
 
@@ -20,24 +19,6 @@ with pacientes as (
 
             upper(equipe_saude_familia [SAFE_OFFSET(0)].nome) as equipe_sf,
             equipe_saude_familia [SAFE_OFFSET(0)].telefone as equipe_sf_telefone
-
-            /* to-do arrays: 
-            endereco.complemento as paciente_complemento_residencia,
-            ebdereco.numero as paciente_numero_residencia,
-            endereco.cep as paciente_cep_residencia,
-            endereco.logradouro as paciente_endereco_residencia,
-            enereco.tipo_logradouro as paciente_tp_logradouro_residencia,
-            endereco.bairro as paciente_bairro_residencia,
-            endereco.cidade as paciente_municipio_residencia,
-            endereco.estado as paciente_uf_residencia,
-
-            contato.telefone.ddd,
-            contato.telefone.valor,
-            contato.email.valor,       
-
-            equipe_saude_familia.id_ine,
-            equipe_saude_familia.clinica_familia.id_cnes,
-            */
 
         from {{ ref("mart_historico_clinico__paciente") }}
         left join {{ ref("dim_estabelecimento") }} as estabs
@@ -57,17 +38,23 @@ with pacientes as (
             p.paciente_nome_social,
             p.paciente_sexo,
             p.paciente_racacor,
-            --p.paciente_nome_pai,
             paciente_obito_ano,
             p.clinica_sf_ap,
             p.clinica_sf,
             p.equipe_sf,
             p.equipe_sf_telefone,
-            p.clinica_sf_telefone
+            p.clinica_sf_telefone,
+
+            -- HCI é um snapshot consolidado: cada paciente aparece uma única vez, já deduplicado
+            -- upstream. Não há "data de atualização por paciente" observável aqui.
+            -- A prioridade do HCI é garantida pela ordem fixa de sistemas, não por data.
+            cast(null as timestamp) as data_atualizacao
         from pacientes p
             left join unnest (p.paciente_cns_array) as cns_item
     )
 
-select distinct * from pacientes_cns_unnested
--- sexo: feminino, masculino
--- racacor: parda, preta, branca, amarela
+select * from pacientes_cns_unnested
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by paciente_cns nulls last
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_minha_saude.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_minha_saude.sql
@@ -1,39 +1,44 @@
 with pacientes as (
-    select distinct
+    select
         -- id
         safe_cast(mongo.cpf as int) as paciente_cpf,
         safe_cast(mongo.cns as int) as paciente_cns,
         safe_cast(mongo.nome as string) as paciente_nome,
         safe_cast(ms.datanascimento as date) as paciente_data_nascimento,
-        
-        case 
+
+        case
             when ms.sexo = 'F' THEN 'FEMININO'
             when ms.sexo = 'M' THEN 'MASCULINO'
         else NULL
         end as paciente_sexo,
 
-        case 
+        case
             when ms.racacor = "None" then NULL
             when ms.racacor = "SEM INFORMACAO" then NULL
             else ms.racacor
         end as paciente_racacor,
 
-        --safe_cast(ms.bairroresidencia as string) as paciente_bairro_residencia,
-        --safe_cast(ms.municipioresidencia as string) as paciente_municipio_residencia,
-        --safe_cast(ms.ufresidencia as string) as paciente_uf_residencia
+        coalesce(
+            safe_cast(ms.ultimaatualizacaocadsus as timestamp),
+            safe_cast(mongo.updatedat as timestamp),
+            safe_cast(ms.datahoracadastro as timestamp)
+        ) as data_atualizacao
 
     from {{ ref("raw_centralderegulacao_mysql__minha_saude__lista_usuario") }} as ms
     left join (
-        select distinct
+        select
             cast(idusuario as string) as idusuario,
             cast(cpf as string) as cpf,
             cast(cns as string) as cns,
-            cast(nome as string) as nome
+            cast(nome as string) as nome,
+            updatedat
         from {{ ref("raw_minhasaude_mongodb__perfil_acessos") }}
     ) as mongo
     on cast(ms.idusuario as string) = mongo.idusuario
     )
 
 select * from pacientes
--- paciente_racacor: AMARELA, BRANCA, INDIGENA, "None", PARDA, PRETA, SEM INFORMACAO
--- paciente_sexo: F, M
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc nulls last
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_ser_ambulatorial.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_ser_ambulatorial.sql
@@ -7,11 +7,17 @@ with pacientes as (
         safe_cast(paciente_data_nascimento as date) as paciente_data_nascimento,
 
         safe_cast(paciente_sexo as string) as paciente_sexo,
-        --safe_cast(paciente_municipio as string) as paciente_municipio_residencia
-        
+
+        -- proxy de atualização cadastral: data da solicitação ambulatorial mais recente no SER.
+        safe_cast(data_solicitacao as timestamp) as data_atualizacao
+
     from {{ ref ("raw_ser_metabase__ambulatorial") }}
     where data_solicitacao >= "2024-01-01"
 )
 
-select distinct * from pacientes
--- paciente_sexo: MASCULINO, FEMININO, NULL
+select * from pacientes
+-- SER ambulatorial não tem cpf; particiona por cns.
+qualify row_number() over (
+    partition by paciente_cns
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_ser_internacoes.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_ser_internacoes.sql
@@ -6,12 +6,18 @@ with pacientes as (
         safe_cast(paciente_nome as string) as paciente_nome,
         safe_cast(paciente_data_nascimento as date) as paciente_data_nascimento,
 
-        --safe_cast(mun.nome_municipio as string) as paciente_municipio_residencia
-        
+        -- proxy de atualização cadastral: data da solicitação de internação mais recente no SER.
+        safe_cast(data_solicitacao as timestamp) as data_atualizacao
+
     from {{ ref("raw_ser_metabase__internacoes") }}
     left join {{ref("raw_sheets__municipios_rio")}} as mun
     on id_paciente_municipio_ibge = safe_cast(mun.cod_ibge_6 as int)
     where data_solicitacao >= "2024-01-01"
 )
 
-select distinct * from pacientes
+select * from pacientes
+-- SER internações não tem cpf; particiona por cns.
+qualify row_number() over (
+    partition by paciente_cns
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sih.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sih.sql
@@ -21,28 +21,23 @@ with pacientes as (
             else NULL 
         end as paciente_racacor,
 
-        /*
-        safe_cast(paciente_mun_origem as string) as paciente_municipio_nascimento,
-        safe_cast(paciente_complemento as string) as paciente_complemento,
-        safe_cast(paciente_numero as string) as paciente_numero,
-        safe_cast(paciente_logradouro as string) as paciente_endereco_residencia,
-        safe_cast(paciente_cep as string) as paciente_cep,
-        safe_cast(paciente_tipo_logradouro as string) as paciente_tp_logradouro_residencia,
-        safe_cast(paciente_bairro as string) as paciente_bairro,
-        safe_cast(mun.nome_municipio as string) as paciente_municipio,
-        safe_cast(paciente_uf as string) as paciente_uf,
-        */
-
         concat(
             coalesce(paciente_tel_ddd, ''),
             coalesce(paciente_tel_num, '')
-        ) as paciente_telefone
-        
+        ) as paciente_telefone,
+
+        -- proxy de atualização cadastral: data de emissão do AIH mais recente.
+        -- escolhemos data_emissao (e não data_internacao) porque representa o momento
+        -- em que o paciente foi registrado no AIH, mais próximo de "cadastro atualizado".
+        safe_cast(data_emissao as timestamp) as data_atualizacao
+
     from {{ ref("raw_sih__autorizacoes_internacoes_hospitalares") }}
     left join {{ref("raw_sheets__municipios_rio")}} as mun
     on safe_cast(paciente_municipio as int) = safe_cast(mun.cod_ibge_6 as int)
 )
 
-select distinct * from pacientes
--- paciente_sexo: I, -, M, F
--- paciente_racacor: 0,1,2,3,4,5,99
+select * from pacientes
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sipni.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sipni.sql
@@ -6,7 +6,6 @@ with pacientes as (
         safe_cast(paciente_nome as string) as paciente_nome, 
         safe_cast(paciente_nascimento_data as date) as paciente_data_nascimento,
         safe_cast(paciente_nome_mae as string) as paciente_nome_mae,
-        --safe_cast(no_pai_paciente as string) as paciente_nome_pai,
         
         case
             when paciente_sexo = 'M' then 'Masculino'
@@ -14,47 +13,15 @@ with pacientes as (
             else NULL
         end as paciente_sexo,
 
-        /*
-        safe_cast(nu_cep_paciente as string) as paciente_cep_residencia,
-        safe_cast(no_bairro_paciente as string) as paciente_bairro_residencia,
-        safe_cast(no_municipio_paciente as string) as paciente_municipio_residencia, 
-        case 
-            when no_uf_paciente = 'ACRE' then 'AC'
-            when no_uf_paciente = 'ALAGOAS' then 'AL'
-            when no_uf_paciente = 'AMAZONAS' then 'AM'
-            when no_uf_paciente = 'AMAPA' then 'AP'
-            when no_uf_paciente = 'BAHIA' then 'BA'
-            when no_uf_paciente = 'CEARA' then 'CE'
-            when no_uf_paciente = 'DISTRITO FEDERAL' then 'DF'
-            when no_uf_paciente = 'ESPIRITO SANTO' then 'ES'
-            when no_uf_paciente = 'GOIAS' then 'GO'
-            when no_uf_paciente = 'MARANHAO' then 'MA'
-            when no_uf_paciente = 'MATO GROSSO' then 'MT'
-            when no_uf_paciente = 'MATO GROSSO DO SUL' then 'MS'
-            when no_uf_paciente = 'MINAS GERAIS' then 'MG'
-            when no_uf_paciente = 'PARA' then 'PA'
-            when no_uf_paciente = 'PARAIBA' then 'PB'
-            when no_uf_paciente = 'PARANA' then 'PR'
-            when no_uf_paciente = 'PERNAMBUCO' then 'PE'
-            when no_uf_paciente = 'PIAUI' then 'PI'
-            when no_uf_paciente = 'RIO DE JANEIRO' then 'RJ'
-            when no_uf_paciente = 'RIO GRANDE DO NORTE' then 'RN'
-            when no_uf_paciente = 'RIO GRANDE DO SUL' then 'RS'
-            when no_uf_paciente = 'RONDONIA' then 'RO'
-            when no_uf_paciente = 'RORAIMA' then 'RR'
-            when no_uf_paciente = 'SANTA CATARINA' then 'SC'
-            when no_uf_paciente = 'SERGIPE' then 'SE'
-            when no_uf_paciente = 'SAO PAULO' then 'SP'
-            when no_uf_paciente = 'TOCANTINS' then 'TO'
-            else NULL
-        end as paciente_uf_residencia,
-        safe_cast(no_pais_paciente as string) as paciente_pais_residencia
-        */
+        -- proxy de atualização cadastral: data da vacinação mais recente no SIPNI.
+        safe_cast(vacina_aplicacao_data as timestamp) as data_atualizacao,
 
     from {{ ref("raw_sipni__vacinacao") }}
     where vacina_aplicacao_data >= "2024-01-01"
 )
 
-select distinct * from pacientes
--- paciente_sexo: M, F, I
--- ufs: RIO DE JANEIRO, SAO PAULO, MINAS GERAIS, AMAPA ..
+select * from pacientes
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_siscan.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_siscan.sql
@@ -15,21 +15,18 @@ with pacientes as (
 
         safe_cast(paciente_idade as int64) as paciente_idade,
         
-        /*
-        safe_cast(paciente_uf as string) as paciente_uf_residencia,
-        safe_cast(paciente_municipio as string) as paciente_municipio_residencia,
-        safe_cast(paciente_cep as string) as paciente_cep_residencia,
-        safe_cast(paciente_bairro as string) as paciente_bairro_residencia,
-        safe_cast(paciente_logradouro as string) as paciente_endereco_residencia,
-        safe_cast(paciente_endereco_complemento as string) as paciente_complemento_residencia,
-        safe_cast(paciente_endereco_numero as string) as paciente_numero_residencia,
-        */
-        
-        safe_cast(paciente_telefone as string) as paciente_telefone
-            
+        safe_cast(paciente_telefone as string) as paciente_telefone,
+
+        -- proxy de atualização cadastral: data do laudo mais recente no SISCAN.
+        safe_cast(data_solicitacao as timestamp) as data_atualizacao
+
     from {{ ref("raw_siscan_web__laudos") }}
     where data_solicitacao >= "2024-01-01"
 )
 
-select distinct * from pacientes 
--- paciente_sexo: Feminino, Masculino
+select * from pacientes
+-- SISCAN não tem cpf; particiona por cns.
+qualify row_number() over (
+    partition by paciente_cns
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sisreg.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_sisreg.sql
@@ -9,25 +9,19 @@ with pacientes as (
 
         safe_cast(paciente_sexo as string) as paciente_sexo,
 
-        /*        
-        safe_cast(paciente_uf_nascimento as string) as paciente_uf_nascimento,
-        safe_cast(paciente_municipio_nascimento as string) as paciente_municipio_nascimento,
+        safe_cast(paciente_telefone as string) as paciente_telefone,
 
-        safe_cast(paciente_complemento_residencia as string) as paciente_complemento_residencia,
-        safe_cast(paciente_numero_residencia as string) as paciente_numero_residencia,
-        safe_cast(paciente_cep_residencia as string) as paciente_cep_residencia,
-        safe_cast(paciente_endereco_residencia as string) as paciente_endereco_residencia,
-        safe_cast(paciente_tp_logradouro_residencia as string) as paciente_tp_logradouro_residencia,
-        safe_cast(paciente_bairro_residencia as string) as paciente_bairro_residencia,
-        safe_cast(paciente_municipio_residencia as string) as paciente_municipio_residencia,
-        safe_cast(paciente_uf_residencia as string) as paciente_uf_residencia,
-        */
+        -- proxy de atualização cadastral: data da última solicitação do paciente no SISREG.
+        -- não é data de atualização do cadastro, mas indica que o paciente estava ativo no sistema.
+        safe_cast(data_solicitacao as timestamp) as data_atualizacao
 
-        safe_cast(paciente_telefone as string) as paciente_telefone
-    
     from {{ ref("mart_sisreg__solicitacoes") }}
     where data_solicitacao >= TIMESTAMP('2024-01-01 00:00:00')
 )
 
-select distinct * from pacientes
--- paciente_sexo: MASCULINO, FEMININO
+select * from pacientes
+-- para cada paciente, mantém apenas o registro da solicitação mais recente.
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_tea.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__pacientes_tea.sql
@@ -1,5 +1,5 @@
 with pacientes as (
-    select  
+    select
         -- id
         safe_cast(usuariocpf as int) as paciente_cpf,
         safe_cast(usuariocns as int) as paciente_cns,
@@ -7,7 +7,10 @@ with pacientes as (
 
         estabs.nome_acentuado as clinica_sf,
         estabs.area_programatica as clinica_sf_ap,
-        estabs.telefone[SAFE_OFFSET(0)] as clinica_sf_telefone
+        estabs.telefone[SAFE_OFFSET(0)] as clinica_sf_telefone,
+
+        -- proxy de atualização cadastral: data da solicitação mais recente no relatório TEA.
+        safe_cast(solicitacaodatahora as timestamp) as data_atualizacao
 
     from {{ ref("raw_centralderegulacao_mysql__tea_relatorio") }}
     left join {{ ref("dim_estabelecimento") }} as estabs
@@ -15,4 +18,8 @@ with pacientes as (
     where date(solicitacaodatahora) >= date '2024-01-01'
 )
 
-select distinct * from pacientes
+select * from pacientes
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__profissionais_cnes.sql
+++ b/models/intermediate/subgeral/dim_paciente/fontes/int_dim_paciente__profissionais_cnes.sql
@@ -1,11 +1,26 @@
 with profissionais as (
-    select 
+    select
         -- id
         safe_cast(cpf as int) as paciente_cpf,
         safe_cast(cns as int) as paciente_cns,
-        safe_cast(nome as string) as paciente_nome
+        safe_cast(nome as string) as paciente_nome,
+
+        -- proxy de atualização cadastral: última competência (ano-mês) em que o profissional
+        -- aparece no CNES. granularidade mensal; usa dia 1 como representação da competência.
+        timestamp(
+            date(
+                safe_cast(ano_competencia as int64),
+                safe_cast(mes_competencia as int64),
+                1
+            )
+        ) as data_atualizacao
+
     from {{ ref("dim_profissional_sus_rio_historico") }}
     where ano_competencia >= 2024
 )
 
-select distinct * from profissionais
+select * from profissionais
+qualify row_number() over (
+    partition by coalesce(safe_cast(paciente_cpf as string), safe_cast(paciente_cns as string))
+    order by data_atualizacao desc
+) = 1

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -37,14 +37,15 @@ with
         group by paciente_cpf
     ),
 
-    -- to do: pegar o registro mais recente ao invés de safe_offset(0)
     enriquece_populacao_interesse as (
         select
             pop.paciente_cpf,
             pop.status,
             bcadastro.nome,
-            
-            dim_paciente.racas_cores [SAFE_OFFSET(0)] as raca_cor,
+
+            -- raça/cor escolhida pela regra de prioridade definida em pacientes_subgeral__dim_paciente:
+            -- bcadastro > hci > minha_saude > resto, com fallback automático quando o vencedor é NULL.
+            dim_paciente.raca_cor as raca_cor,
 
             -- DDI é opcional: substituído por '' para não propagar NULL no concat.
             -- DDD e número precisam estar presentes para montar o telefone.
@@ -73,11 +74,15 @@ with
                 0
             ) as idade,
 
-            dim_paciente.clinicas_sf [SAFE_OFFSET(0)] as clinica_sf,
-            dim_paciente.clinicas_sf_ap [SAFE_OFFSET(0)] as clinica_sf_ap,
-            dim_paciente.clinicas_sf_telefone [SAFE_OFFSET(0)] as clinica_sf_telefone,
-            dim_paciente.equipes_sf [SAFE_OFFSET(0)] as equipe_sf,
-            dim_paciente.equipes_sf_telefone[SAFE_OFFSET(0)] as equipe_sf_telefone,
+            -- vínculo APS sempre vem do HCI (cadastro consolidado da APS). pacientes que
+            -- não estão no HCI ficam com esses campos NULL. todos os campos vêm do MESMO
+            -- registro do HCI — elimina o desalinhamento do SAFE_OFFSET(0) anterior entre
+            -- arrays paralelos.
+            dim_paciente.clinica_sf as clinica_sf,
+            dim_paciente.clinica_sf_ap as clinica_sf_ap,
+            dim_paciente.clinica_sf_telefone as clinica_sf_telefone,
+            dim_paciente.equipe_sf as equipe_sf,
+            dim_paciente.equipe_sf_telefone as equipe_sf_telefone,
 
             dsr.dias_sem_resposta as gravidade_score
 

--- a/models/marts/subgeral/pacientes_subgeral/_pacientes_subgeral__models.yml
+++ b/models/marts/subgeral/pacientes_subgeral/_pacientes_subgeral__models.yml
@@ -1,0 +1,116 @@
+version: 2
+
+models:
+  - name: pacientes_subgeral__cadastros
+    description: |
+      União canônica dos cadastros de pacientes nos sistemas transacionais.
+      Cada linha é um paciente em um sistema (sisreg, siscan, hci, minha_saude, etc.),
+      já com cpf padronizado (com zeros à esquerda) e CNS resolvido quando aplicável.
+      Cada sistema contribui com no máximo 1 linha por paciente: o registro mais recente
+      daquela fonte (deduplicado nos modelos intermediários por data_atualizacao).
+
+      Fontes excluídas desta união (usadas apenas para enriquecimento em dim_paciente):
+      - receita_federal (bcadastro): tabela muito grande; não são pacientes, são cidadãos.
+      - profissionais_cnes: cadastro de profissionais de saúde, não de pacientes.
+    columns:
+      - name: paciente_cpf
+        description: CPF do paciente com 11 dígitos (zeros à esquerda quando necessário).
+      - name: cpf_particao
+        description: CPF como inteiro, usado como chave de partição.
+      - name: sistema_origem
+        description: Nome do sistema do qual o registro foi extraído.
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - sisreg
+                - siscan
+                - ser_internacoes
+                - ser_ambulatorial
+                - sih
+                - minha_saude
+                - tea
+                - fibromialgia
+                - sipni
+                - hci
+      - name: data_atualizacao
+        description: |
+          Data que indica a recência do registro do paciente naquela fonte. A semântica
+          varia por sistema:
+          - minha_saude: data real de atualização do cadastro no CADSUS (ultimaatualizacaocadsus).
+          - sisreg, siscan, ser_*, sih, sipni, tea, fibromialgia: data do evento mais recente
+            do paciente naquele sistema (proxy).
+          - hci = NULL. não tem uma data de atualização por paciente semanticamente útil.
+            a priorização é garantida por ordem fixa em pacientes_subgeral__dim_paciente.
+
+  - name: pacientes_subgeral__dim_paciente
+    description: |
+      Dimensão de paciente consolidada a partir de todos os sistemas. Uma linha por CPF,
+      com atributos escalares prontos para uso operacional (busca ativa, contato, ficha do
+      paciente) e arrays de histórico para auditoria. Materializada como tabela porque a
+      lógica de consolidação é cara para reprocessar a cada consulta (tag: weekly).
+
+      Regras de seleção dos campos escalares:
+      - Atributos pessoais (nome, nome_mae, nome_social, data_nascimento, sexo, raca_cor,
+        obito_ano): prioridade fixa receita_federal (bcadastro) > hci > minha_saude > resto,
+        com desempate pela data_atualizacao mais recente. Cada campo é escolhido de forma
+        INDEPENDENTE. Se a fonte vencedora tiver NULL naquele campo, o valor cai para a
+        próxima fonte da ordem. Consequência: dois campos do mesmo paciente podem vir de
+        fontes diferentes, sempre escolhendo o melhor disponível.
+      - Vínculo APS (clinica_sf, clinica_sf_ap, clinica_sf_telefone, equipe_sf,
+        equipe_sf_telefone): SEMPRE do HCI. Pacientes que não aparecem no HCI ficam com
+        esses campos NULL (esperado).
+    columns:
+      - name: cpf
+        description: CPF do paciente em string com 11 dígitos (zeros à esquerda).
+        data_tests:
+          - not_null
+          - unique
+      - name: cpf_particao
+        description: CPF como inteiro, chave de partição da tabela.
+        data_tests:
+          - not_null
+      - name: nome
+        description: Nome do paciente, escolhido pela regra de prioridade entre fontes.
+      - name: nome_mae
+        description: Nome da mãe do paciente, escolhido pela regra de prioridade entre fontes.
+      - name: nome_social
+        description: Nome social do paciente, escolhido pela regra de prioridade entre fontes.
+      - name: data_nascimento
+        description: Data de nascimento do paciente, escolhida pela regra de prioridade entre fontes.
+      - name: sexo
+        description: Sexo do paciente (FEMININO, MASCULINO), escolhido pela regra de prioridade entre fontes.
+      - name: raca_cor
+        description: Raça/cor do paciente, escolhida pela regra de prioridade entre fontes.
+      - name: obito_ano
+        description: Ano de óbito do paciente, escolhido pela regra de prioridade entre fontes. NULL para pacientes vivos.
+      - name: clinica_sf
+        description: Clínica de saúde da família vinculada ao paciente. Sempre do HCI; NULL quando o paciente não está no HCI.
+      - name: clinica_sf_ap
+        description: Área Programática (AP) da clínica de saúde da família. Sempre do HCI.
+      - name: clinica_sf_telefone
+        description: Telefone da clínica de saúde da família. Sempre do HCI.
+      - name: equipe_sf
+        description: Equipe de saúde da família vinculada ao paciente. Sempre do HCI.
+      - name: equipe_sf_telefone
+        description: Telefone da equipe de saúde da família. Sempre do HCI.
+      - name: sistemas_origem
+        description: Lista de sistemas onde este paciente aparece.
+      - name: n_registros
+        description: Total de registros (linhas em cadastros) que se referem a este paciente.
+      - name: cns_lista
+        description: Lista de CNS (cartão SUS) já vistos para este paciente.
+      - name: nomes
+        description: Lista de variações do nome do paciente já vistas em qualquer sistema.
+      - name: nomes_mae
+        description: Lista de variações do nome da mãe do paciente.
+      - name: nomes_sociais
+        description: Lista de variações do nome social do paciente.
+      - name: datas_nascimento
+        description: Lista de datas de nascimento já vistas (em string) — útil para detectar discrepâncias entre sistemas.
+      - name: sexos
+        description: Lista de valores de sexo já vistos (FEMININO, MASCULINO).
+      - name: racas_cores
+        description: Lista de valores de raça/cor já vistos.
+      - name: anos_obito
+        description: Lista de anos de óbito declarados em qualquer sistema. Se não for vazia, considere o paciente como óbito.

--- a/models/marts/subgeral/pacientes_subgeral/_pacientes_subgeral__models.yml
+++ b/models/marts/subgeral/pacientes_subgeral/_pacientes_subgeral__models.yml
@@ -15,8 +15,12 @@ models:
     columns:
       - name: paciente_cpf
         description: CPF do paciente com 11 dígitos (zeros à esquerda quando necessário).
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
       - name: cpf_particao
         description: CPF como inteiro, usado como chave de partição.
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
       - name: sistema_origem
         description: Nome do sistema do qual o registro foi extraído.
         data_tests:
@@ -63,21 +67,33 @@ models:
     columns:
       - name: cpf
         description: CPF do paciente em string com 11 dígitos (zeros à esquerda).
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
         data_tests:
           - not_null
           - unique
       - name: cpf_particao
         description: CPF como inteiro, chave de partição da tabela.
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
         data_tests:
           - not_null
       - name: nome
         description: Nome do paciente, escolhido pela regra de prioridade entre fontes.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
       - name: nome_mae
         description: Nome da mãe do paciente, escolhido pela regra de prioridade entre fontes.
+        policy_tags:
+          - '{{ var("TAG_NOME_MAE") }}'
       - name: nome_social
         description: Nome social do paciente, escolhido pela regra de prioridade entre fontes.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
       - name: data_nascimento
         description: Data de nascimento do paciente, escolhida pela regra de prioridade entre fontes.
+        policy_tags:
+          - '{{ var("TAG_DATA_NASCIMENTO") }}'
       - name: sexo
         description: Sexo do paciente (FEMININO, MASCULINO), escolhido pela regra de prioridade entre fontes.
       - name: raca_cor
@@ -100,14 +116,24 @@ models:
         description: Total de registros (linhas em cadastros) que se referem a este paciente.
       - name: cns_lista
         description: Lista de CNS (cartão SUS) já vistos para este paciente.
+        policy_tags:
+          - '{{ var("TAG_CNS") }}'
       - name: nomes
         description: Lista de variações do nome do paciente já vistas em qualquer sistema.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
       - name: nomes_mae
         description: Lista de variações do nome da mãe do paciente.
+        policy_tags:
+          - '{{ var("TAG_NOME_MAE") }}'
       - name: nomes_sociais
         description: Lista de variações do nome social do paciente.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
       - name: datas_nascimento
         description: Lista de datas de nascimento já vistas (em string) — útil para detectar discrepâncias entre sistemas.
+        policy_tags:
+          - '{{ var("TAG_DATA_NASCIMENTO") }}'
       - name: sexos
         description: Lista de valores de sexo já vistos (FEMININO, MASCULINO).
       - name: racas_cores

--- a/models/marts/subgeral/pacientes_subgeral/pacientes_subgeral__cadastros.sql
+++ b/models/marts/subgeral/pacientes_subgeral/pacientes_subgeral__cadastros.sql
@@ -27,30 +27,12 @@ with
             paciente_cns,
             paciente_nome,
             paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
     -- sociodemograficos
             paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-    -- endereco
-            /*
-            paciente_uf_nascimento,
-            paciente_municipio_nascimento,
-            paciente_uf_residencia,
-            paciente_municipio_residencia,
-            paciente_bairro_residencia,
-            paciente_cep_residencia,
-            paciente_endereco_residencia,
-            paciente_complemento_residencia,
-            paciente_numero_residencia,
-            paciente_tp_logradouro_residencia,
-            
-            paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -59,7 +41,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone      
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao  
         from {{ref("int_dim_paciente__pacientes_sisreg")}}
 
         union all
@@ -71,28 +54,11 @@ with
             paciente_cns,
             paciente_nome,
             paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            paciente_uf_residencia,
-            paciente_municipio_residencia,
-            paciente_bairro_residencia,
-            paciente_cep_residencia,
-            paciente_endereco_residencia,
-            paciente_complemento_residencia,
-            paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-            
-            --paciente_telefone,
-            --cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -101,7 +67,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_siscan")}}
 
         union all
@@ -113,28 +80,11 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             cast(null as string) as paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            cast(null as string) as paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -143,7 +93,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_ser_internacoes")}}
 
         union all
@@ -155,28 +106,11 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-            
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -185,7 +119,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_ser_ambulatorial")}}
 
         union all
@@ -197,29 +132,12 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             paciente_sexo,
             paciente_racacor,
 
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            paciente_municipio_nascimento,
-            paciente_uf as paciente_uf_residencia,
-            paciente_municipio as paciente_municipio_residencia,
-            paciente_bairro as paciente_bairro_residencia,
-            paciente_cep as paciente_cep_residencia,
-            paciente_endereco_residencia,
-            paciente_complemento as paciente_complemento_residencia,
-            paciente_numero as paciente_numero_residencia,
-            paciente_tp_logradouro_residencia,
-
-            paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
-
             cast(null as int) as paciente_obito_ano,
 
             cast(null as string) as clinica_sf,
@@ -227,50 +145,9 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_sih")}}
-
-        union all
-
-        select
-            'profissionais_cnes' as sistema_origem,
-
-            paciente_cpf,
-            paciente_cns,
-            paciente_nome,
-            cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
-            cast(null as date) as paciente_data_nascimento,
-            cast(null as string) as paciente_nome_social,
-
-            cast(null as string) as paciente_sexo,
-            cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            cast(null as string) as paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
-
-            cast(null as int) as paciente_obito_ano,
-
-            cast(null as string) as clinica_sf,
-            cast(null as string) as clinica_sf_ap,
-            cast(null as string) as clinica_sf_telefone,
-
-            cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
-        from {{ref("int_dim_paciente__profissionais_cnes")}}
 
         union all
 
@@ -281,28 +158,11 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             paciente_sexo,
             paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            paciente_uf_residencia,
-            paciente_municipio_residencia,
-            paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -311,7 +171,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_minha_saude")}}
 
         union all
@@ -323,28 +184,11 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             cast(null as date) as paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             cast(null as string) as paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            cast(null as string) as paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -353,7 +197,8 @@ with
             clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_tea")}}
 
         union all
@@ -365,28 +210,11 @@ with
             paciente_cns,
             paciente_nome,
             cast(null as string) as paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
             cast(null as date) as paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             cast(null as string) as paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            cast(null as string) as paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -395,7 +223,8 @@ with
             clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_fibromialgia")}}
 
         union all
@@ -407,28 +236,11 @@ with
             paciente_cns,
             paciente_nome,
             paciente_nome_mae,
-            --paciente_nome_pai,
             paciente_data_nascimento,
             cast(null as string) as paciente_nome_social,
 
             cast(null as string) as paciente_sexo,
             cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            paciente_uf_residencia,
-            paciente_municipio_residencia,
-            paciente_bairro_residencia,
-            paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             cast(null as int) as paciente_obito_ano,
 
@@ -437,7 +249,8 @@ with
             cast(null as string) as clinica_sf_telefone,
 
             cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
+            cast(null as string) as equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_sipni")}}
 
         union all
@@ -449,28 +262,11 @@ with
             paciente_cns,
             paciente_nome,
             paciente_nome_mae,
-            --paciente_nome_pai,
             paciente_data_nascimento,
             paciente_nome_social,
 
             paciente_sexo,
             paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            cast(null as string) as paciente_uf_residencia,
-            cast(null as string) as paciente_municipio_residencia,
-            cast(null as string) as paciente_bairro_residencia,
-            cast(null as string) as paciente_cep_residencia,
-            cast(null as string) as paciente_endereco_residencia,
-            cast(null as string) as paciente_complemento_residencia,
-            cast(null as string) as paciente_numero_residencia,
-            cast(null as string) as paciente_tp_logradouro_residencia,
-            
-            cast(null as string) as paciente_telefone,
-            cast(null as string) as paciente_email,
-            */
 
             paciente_obito_ano,
 
@@ -479,50 +275,9 @@ with
             clinica_sf_telefone,
 
             equipe_sf,
-            equipe_sf_telefone
+            equipe_sf_telefone,
+            data_atualizacao
         from {{ref("int_dim_paciente__pacientes_hci")}}
-
-        union all
-
-        select
-            'receita_federal' as sistema_origem,
-
-            paciente_cpf,
-            cast(null as int) as paciente_cns,
-            paciente_nome,
-            paciente_nome_mae,
-            --cast(null as string) as paciente_nome_pai,
-            paciente_data_nascimento,
-            paciente_nome_social,
-
-            paciente_sexo,
-            cast(null as string) as paciente_racacor,
-
-            /*
-            cast(null as string) as paciente_uf_nascimento,
-            cast(null as string) as paciente_municipio_nascimento,
-            paciente_uf_residencia,
-            paciente_municipio_residencia,
-            paciente_bairro_residencia,
-            paciente_cep_residencia,
-            paciente_endereco_residencia,
-            paciente_complemento_residencia,
-            paciente_numero_residencia,
-            paciente_tp_logradouro_residencia,
-
-            paciente_telefone,
-            paciente_email,
-            */
-            
-            paciente_obito_ano,
-
-            cast(null as string) as clinica_sf,
-            cast(null as string) as clinica_sf_ap,
-            cast(null as string) as clinica_sf_telefone,
-
-            cast(null as string) as equipe_sf,
-            cast(null as string) as equipe_sf_telefone    
-        from {{ref("int_dim_paciente__pacientes_bcadastro")}}
     ),
 
 -- backfill cpf
@@ -544,7 +299,6 @@ with
             ar.paciente_cns,
             ar.paciente_nome,
             ar.paciente_nome_mae,
-            --ar.paciente_nome_pai,
             ar.paciente_nome_social,
 
             ar.paciente_data_nascimento,
@@ -562,22 +316,6 @@ with
                 ) then null
                 else ar.paciente_racacor
             end as paciente_racacor, 
-
-            /*
-            ar.paciente_uf_nascimento,
-            ar.paciente_municipio_nascimento,
-            ar.paciente_uf_residencia,
-            ar.paciente_municipio_residencia,
-            ar.paciente_bairro_residencia,
-            ar.paciente_cep_residencia,
-            ar.paciente_endereco_residencia,
-            ar.paciente_complemento_residencia,
-            ar.paciente_numero_residencia,
-            ar.paciente_tp_logradouro_residencia,
-            
-            ar.paciente_telefone,
-            ar.paciente_email,
-            */
             
             ar.paciente_obito_ano,
 
@@ -586,7 +324,9 @@ with
             ar.clinica_sf_telefone,
 
             ar.equipe_sf,
-            ar.equipe_sf_telefone
+            ar.equipe_sf_telefone,
+
+            ar.data_atualizacao
         from todos_registros ar
             left join {{ref("pacientes_subgeral__relacao_cns_cpf")}} m
             on safe_cast(ar.paciente_cns as int) = safe_cast(m.cns as int)

--- a/models/marts/subgeral/pacientes_subgeral/pacientes_subgeral__dim_paciente.sql
+++ b/models/marts/subgeral/pacientes_subgeral/pacientes_subgeral__dim_paciente.sql
@@ -3,6 +3,7 @@
 {{
   config(
     enabled=true,
+    materialized='table',
     schema="pacientes_subgeral",
     alias="dim_paciente_subgeral",
     unique_key='cpf',
@@ -17,95 +18,174 @@
 }}
 
 with
-agg as (
-  select
-    cpf_particao,
-
-    array_agg(distinct sistema_origem ignore nulls) as sistemas_origem,
-    count(*) as n_registros,
-
-    array_agg(distinct paciente_cns ignore nulls) as cns_lista,
-
-    array_agg(distinct paciente_nome ignore nulls) as nomes,
-    array_agg(distinct paciente_nome_mae ignore nulls) as nomes_mae,
-    --array_agg(distinct paciente_nome_pai ignore nulls) as nomes_pai,
-    array_agg(distinct paciente_nome_social ignore nulls) as nomes_sociais,
-
-    array_agg(distinct cast(paciente_data_nascimento as string) ignore nulls) as datas_nascimento,
-    array_agg(distinct paciente_sexo ignore nulls) as sexos,
-    array_agg(distinct paciente_racacor ignore nulls) as racas_cores,
-    
-    --array_agg(distinct paciente_uf_nascimento ignore nulls) as ufs_nascimento,
-    --array_agg(distinct paciente_municipio_nascimento ignore nulls) as municipios_nascimento,
-
-    --array_agg(distinct paciente_uf_residencia ignore nulls) as ufs_residencia,
-    --array_agg(distinct paciente_municipio_residencia ignore nulls) as municipios_residencia,
-    --array_agg(distinct paciente_bairro_residencia ignore nulls) as bairros_residencia,
-    --array_agg(distinct paciente_cep_residencia ignore nulls) as ceps_residencia,
-    --array_agg(distinct paciente_endereco_residencia ignore nulls) as enderecos_residencia,
-    --array_agg(distinct paciente_complemento_residencia ignore nulls) as complementos_residencia,
-    --array_agg(distinct paciente_numero_residencia ignore nulls) as numeros_residencia,
-    --array_agg(distinct paciente_tp_logradouro_residencia ignore nulls) as tipos_logradouro_residencia,
-    
-
-    --array_agg(distinct paciente_telefone ignore nulls) as telefones,
-    --array_agg(distinct paciente_email ignore nulls) as emails,
-
-    array_agg(distinct paciente_obito_ano ignore nulls) as anos_obito,
-
-    array_agg(distinct clinica_sf ignore nulls) as clinicas_sf,
-    array_agg(distinct clinica_sf_ap ignore nulls) as clinicas_sf_ap,
-    array_agg(distinct clinica_sf_telefone ignore nulls) as clinicas_sf_telefone,
-
-    array_agg(distinct equipe_sf ignore nulls) as equipes_sf,
-    array_agg(distinct equipe_sf_telefone ignore nulls) as equipes_sf_telefone
-
-  from {{ref("pacientes_subgeral__cadastros")}} as agg_src
-  where paciente_cpf is not null
-  group by cpf_particao
+-- cada linha é um registro de um paciente em um sistema de origem (já deduplicado
+-- upstream para 1 linha por paciente por sistema, com data_atualizacao do registro).
+registros_base as (
+    select *
+    from {{ref("pacientes_subgeral__cadastros")}}
+    where paciente_cpf is not null
 ),
 
+-- todos os valores já vistos em qualquer sistema.
+-- útil para detectar discrepâncias entre fontes (ex.: nomes ligeiramente diferentes
+-- ou datas de nascimento divergentes em sistemas distintos).
+historico as (
+    select
+        cpf_particao,
+
+        array_agg(distinct sistema_origem ignore nulls) as sistemas_origem,
+        count(*) as n_registros,
+
+        array_agg(distinct paciente_cns ignore nulls) as cns_lista,
+
+        array_agg(distinct paciente_nome ignore nulls) as nomes,
+        array_agg(distinct paciente_nome_mae ignore nulls) as nomes_mae,
+        array_agg(distinct paciente_nome_social ignore nulls) as nomes_sociais,
+        array_agg(distinct cast(paciente_data_nascimento as string) ignore nulls) as datas_nascimento,
+        array_agg(distinct paciente_sexo ignore nulls) as sexos,
+        array_agg(distinct paciente_racacor ignore nulls) as racas_cores,
+        array_agg(distinct paciente_obito_ano ignore nulls) as anos_obito
+
+    from registros_base
+    group by cpf_particao
+),
+
+-- VÍNCULO APS: sempre do HCI
+vinculo_aps as (
+    select
+        cpf_particao,
+        clinica_sf,
+        clinica_sf_ap,
+        clinica_sf_telefone,
+        equipe_sf,
+        equipe_sf_telefone
+    from registros_base
+    where sistema_origem = 'hci'
+),
+
+-- bcadastro é usado apenas para enriquecimento de atributos pessoais: lê somente
+-- pacientes já descobertos em outras fontes (inner join), evitando varrer a tabela
+-- inteira da Receita Federal. não contribui com novas linhas em registros_base.
+enriquecimento_bcadastro as (
+    select
+        rb.cpf_particao,
+        bc.paciente_nome,
+        bc.paciente_nome_mae,
+        bc.paciente_nome_social,
+        bc.paciente_data_nascimento,
+        bc.paciente_sexo,
+        bc.paciente_obito_ano,
+        bc.data_atualizacao
+    from (select distinct cpf_particao from registros_base) as rb
+    inner join {{ref("int_dim_paciente__pacientes_bcadastro")}} as bc
+        on rb.cpf_particao = bc.paciente_cpf
+),
+
+-- ATRIBUTOS PESSOAIS PRINCIPAIS
+-- regra: prioridade fixa receita_federal (bcadastro) > hci > minha_saude > resto.
+-- desempate por data_atualizacao mais recente.
+-- bcadastro não está em registros_base (não é fonte de descoberta de pacientes),
+-- mas participa do ranking via enriquecimento_bcadastro (inner join).
+-- cada campo é escolhido INDEPENDENTEMENTE: se a fonte vencedora tiver null naquele
+-- campo, o valor cai para a próxima fonte da ordem (via first_value ignore nulls).
+-- consequência: campos diferentes do mesmo paciente podem vir de fontes distintas.
+atributos_pessoais_rankeados as (
+    select
+        cpf_particao,
+        paciente_nome,
+        paciente_nome_mae,
+        paciente_nome_social,
+        paciente_data_nascimento,
+        paciente_sexo,
+        paciente_racacor,
+        paciente_obito_ano,
+        data_atualizacao,
+        case sistema_origem
+            when 'hci' then 2
+            when 'minha_saude' then 3
+            else 4
+        end as prioridade_pessoal
+    from registros_base
+
+    union all
+
+    -- receita_federal: prioridade máxima para atributos pessoais.
+    -- nota: bcadastro não tem raca_cor - esse campo virá da próxima fonte disponível.
+    select
+        cpf_particao,
+        paciente_nome,
+        paciente_nome_mae,
+        paciente_nome_social,
+        paciente_data_nascimento,
+        paciente_sexo,
+        cast(null as string) as paciente_racacor,
+        paciente_obito_ano,
+        data_atualizacao,
+        1 as prioridade_pessoal
+    from enriquecimento_bcadastro
+),
+
+atributos_pessoais as (
+    select distinct
+        cpf_particao,
+
+        first_value(paciente_nome ignore nulls) over w as nome,
+        first_value(paciente_nome_mae ignore nulls) over w as nome_mae,
+        first_value(paciente_nome_social ignore nulls) over w as nome_social,
+        first_value(paciente_data_nascimento ignore nulls) over w as data_nascimento,
+        first_value(paciente_sexo ignore nulls) over w as sexo,
+        first_value(paciente_racacor ignore nulls) over w as raca_cor,
+        first_value(paciente_obito_ano ignore nulls) over w as obito_ano
+
+    from atributos_pessoais_rankeados
+    window w as (
+        partition by cpf_particao
+        order by prioridade_pessoal asc, data_atualizacao desc nulls last
+        rows between unbounded preceding and unbounded following
+    )
+),
+
+-- 1 linha por paciente, atributos escalares + arrays de histórico
 final as (
-  select
-    lpad(safe_cast(cpf_particao as string), 11) as cpf,
-    cpf_particao,
-    sistemas_origem,
-    n_registros,
-    cns_lista,
+    select
+        lpad(safe_cast(h.cpf_particao as string), 11, '0') as cpf,
+        h.cpf_particao,
 
-    nomes,
-    datas_nascimento,
-    nomes_mae,
-    --nomes_pai,
+        -- atributos pessoais escolhidos pela regra de prioridade.
+        ap.nome,
+        ap.nome_mae,
+        ap.nome_social,
+        ap.data_nascimento,
+        ap.sexo,
+        ap.raca_cor,
+        ap.obito_ano,
 
-    sexos,
-    racas_cores,
-    
-    --ufs_nascimento,
-    --municipios_nascimento,
+        -- vínculo APS: sempre do HCI. NULL quando o paciente não está no HCI.
+        v.clinica_sf,
+        v.clinica_sf_ap,
+        v.clinica_sf_telefone,
+        v.equipe_sf,
+        v.equipe_sf_telefone,
 
-    --ufs_residencia,
-    --municipios_residencia,
-    --bairros_residencia,
-    --ceps_residencia,
-    --enderecos_residencia,
-    --complementos_residencia,
-    --numeros_residencia,
-    --tipos_logradouro_residencia,
+        -- metadados de proveniência.
+        h.sistemas_origem,
+        h.n_registros,
+        h.cns_lista,
 
-    --telefones,
-    --emails,
-    
-    anos_obito,
+        -- arrays de histórico para auditoria (todos os valores já vistos em qualquer sistema).
+        h.nomes,
+        h.nomes_mae,
+        h.nomes_sociais,
+        h.datas_nascimento,
+        h.sexos,
+        h.racas_cores,
+        h.anos_obito
 
-    clinicas_sf,
-    clinicas_sf_ap,
-    clinicas_sf_telefone,
-
-    equipes_sf,
-    equipes_sf_telefone
-    
-  from agg
+    from historico as h
+    left join atributos_pessoais as ap
+        on h.cpf_particao = ap.cpf_particao
+    left join vinculo_aps as v
+        on h.cpf_particao = v.cpf_particao
 )
 
 select * from final


### PR DESCRIPTION
Refactor the patient data model to include a `data_atualizacao` field for tracking the most recent updates, remove outdated sources, and enhance the model with policy tags. Documentation in YAML format has been added for clarity.