### PR TITLE
Adiciona alterações nos modelos utilizados nos protocolos do PIC

### DIFF
--- a/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__prontuaRio.sql
+++ b/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__prontuaRio.sql
@@ -148,10 +148,21 @@ triagem as (
         struct(
           cid as id,
           nome as descricao,
-          cast(null as string) as situacao,
+          -- O prontuaRio não informa situacao do CID. Para preservar a fonte original, a situacao permanece nula na maioria dos casos.
+          -- Exceção: quando o CID indica desfecho obstétrico (parto, aborto ou pós-parto),
+          -- a modelagem deriva situacao = 'RESOLVIDO' para permitir identificar o fim da gestação 
+          -- isso é utilizado nos modelos dashboard_gestacoes da SAP
+          case
+            when regexp_contains(cid, r'^O8[0-4]$')
+              or regexp_contains(cid, r'^Z37')
+              or regexp_contains(cid, r'^Z39')
+              or regexp_contains(cid, r'^O0[0-4]$')
+            then 'RESOLVIDO'
+            else cast(null as string)
+          end as situacao,
           cast(internacao_data as string) as data_diagnostico
         )
-      ) as condicoes,
+      ) as condicoes
     from emerg_cid
     group by gid_boletim
   ),
@@ -310,7 +321,18 @@ inter_saida as (
         struct(
           id,
           descricao,
-          cast(null as string) as situacao,
+          -- O prontuaRio não informa situacao do CID. Para preservar a fonte original, a situacao permanece nula na maioria dos casos.
+          -- Exceção: quando o CID indica desfecho obstétrico (parto, aborto ou pós-parto),
+          -- a modelagem deriva situacao = 'RESOLVIDO' para permitir identificar o fim da gestação 
+          -- isso é utilizado nos modelos dashboard_gestacoes da SAP
+          case
+            when regexp_contains(id, r'^O8[0-4]$')
+              or regexp_contains(id, r'^Z37')
+              or regexp_contains(id, r'^Z39')
+              or regexp_contains(id, r'^O0[0-4]$')
+            then 'RESOLVIDO'
+            else cast(null as string)
+          end as situacao,
           cast(internacao_data as string) as data_diagnostico
         )
       ) as condicoes

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
@@ -97,10 +97,7 @@ WITH
         FROM {{ ref("raw_prontuario_vitacare__atendimento") }}
         WHERE cpf IS NOT NULL
         AND NOT REGEXP_CONTAINS(tipo, r'(?i)visita')
-        AND (
-                REGEXP_CONTAINS(normalize_and_casefold(cbo_descricao_profissional, NFKD), r"medico")
-            OR REGEXP_CONTAINS(normalize_and_casefold(cbo_descricao_profissional, NFKD), r"enfermeiro")
-        )
+        AND REGEXP_CONTAINS(REGEXP_REPLACE(NORMALIZE_AND_CASEFOLD(cbo_descricao_profissional, NFKD), r'\pM',''), r'medico|enfermeiro')
     ),
 
     -- TESTES RÁPIDOS

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
@@ -83,8 +83,7 @@ WITH
         FROM {{ ref("raw_prontuario_vitacare__atendimento") }}
         WHERE REGEXP_CONTAINS(tipo, r'(?i)visita')
           AND cpf IS NOT NULL
-          AND cpf <> 'NAO TEM'
-          AND cbo_profissional = '515105' -- apenas ACS
+          AND cbo_profissional IN ('515105', '322255') -- ACS e Técnico de Agente Comunitário
     ),
 
     -- CONSULTAS

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
@@ -88,6 +88,8 @@ WITH
     ),
 
     -- CONSULTAS
+    -- Considera apenas consultas realizadas por médico ou enfermeiro,
+    -- pois este é o conceito de consulta utilizado pelos protocolos do PIC.
     consultas AS (
         SELECT
             cpf,
@@ -95,24 +97,11 @@ WITH
             COALESCE(datahora_fim, datahora_inicio) AS dthr
         FROM {{ ref("raw_prontuario_vitacare__atendimento") }}
         WHERE cpf IS NOT NULL
-          AND cpf <> 'NAO TEM'
-          AND NOT REGEXP_CONTAINS(tipo, r'(?i)visita')
-    ),
-
-    -- CONSULTAS MÉDICO/ENFERMEIRO
-    consultas_medico_enfermeiro AS (
-        SELECT
-            cpf,
-            'Consulta - Médico/Enfermeiro' AS tipo_evento,
-            COALESCE(datahora_fim, datahora_inicio) AS dthr
-        FROM {{ ref("raw_prontuario_vitacare__atendimento") }}
-        WHERE cpf IS NOT NULL
-          AND cpf <> 'NAO TEM'
-          AND NOT REGEXP_CONTAINS(tipo, r'(?i)visita')
-          AND (
+        AND NOT REGEXP_CONTAINS(tipo, r'(?i)visita')
+        AND (
                 REGEXP_CONTAINS(normalize_and_casefold(cbo_descricao_profissional, NFKD), r"medico")
-             OR REGEXP_CONTAINS(normalize_and_casefold(cbo_descricao_profissional, NFKD), r"enfermeiro")
-          )
+            OR REGEXP_CONTAINS(normalize_and_casefold(cbo_descricao_profissional, NFKD), r"enfermeiro")
+        )
     ),
 
     -- TESTES RÁPIDOS
@@ -257,8 +246,6 @@ WITH
         SELECT * FROM visitas_domiciliares
         UNION ALL
         SELECT * FROM consultas
-        UNION ALL
-        SELECT * FROM consultas_medico_enfermeiro
         UNION ALL
         SELECT * FROM vacinacoes
         UNION ALL

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
@@ -26,7 +26,6 @@ WITH
                 ROW_NUMBER() OVER (PARTITION BY cpf ORDER BY data_inicio DESC) AS rn
             FROM {{ ref('mart_bi_gestacoes__gestacoes') }}
             WHERE fase_atual = 'Puerpério'
-            AND data_fim IS NOT NULL
             AND data_fim_efetiva IS NOT NULL
             AND cpf IS NOT NULL
         )
@@ -57,8 +56,8 @@ WITH
         -- Puerpério atual
         SELECT
             cpf,
-            data_fim AS inicio_fase,
-            DATE_ADD(data_fim, INTERVAL 45 DAY) AS fim_fase,
+            data_fim_efetiva AS inicio_fase,
+            DATE_ADD(data_fim_efetiva, INTERVAL 45 DAY) AS fim_fase,
             'Puerperio' AS tipo_publico
         FROM puerperio_dedup
 

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__publico_alvo.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__publico_alvo.sql
@@ -36,12 +36,12 @@ gestacoes_em_andamento AS (
 puerperio_atual AS (
     SELECT
         cpf,
-        data_fim AS inicio,
-        DATE_ADD(data_fim, INTERVAL 45 DAY) AS fim,
+        data_fim_efetiva AS inicio, -- data_fim_efetiva é data de encerramento do CID quando houver; caso contrário, data_inicio + 300 dias, como encerramento automático da gestação.
+        DATE_ADD(data_fim_efetiva, INTERVAL 45 DAY) AS fim,
         'Puerperio' AS tipo_publico
     FROM gestacoes_base
     WHERE fase_atual = 'Puerpério'
-      AND data_fim IS NOT NULL
+      AND data_fim_efetiva IS NOT NULL
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY cpf
         ORDER BY data_inicio DESC, data_fim DESC, data_fim_efetiva DESC

--- a/models/raw/prontuario_vitacare/raw_prontuario_vitacare__atendimento.sql
+++ b/models/raw/prontuario_vitacare/raw_prontuario_vitacare__atendimento.sql
@@ -58,7 +58,7 @@ select
     id_prontuario_local,
     id_prontuario_global,
     id_hci,
-    cpf,
+    {{ clean_numeric("cpf") }} as cpf,
     cnes_unidade,
     cns_profissional,
     cpf_profissional,


### PR DESCRIPTION
Este PR consolida ajustes nos modelos base utilizados pelos protocolos do PIC, com foco em alinhar a modelagem às regras discutidas com produto e corrigir inconsistências que estavam impactando a classificação de público-alvo e eventos.

As principais alterações foram:

* ajuste do `prontuaRio` para derivar `situacao = 'RESOLVIDO'` apenas em CIDs de desfecho obstétrico, permitindo identificar melhor o encerramento da gestação nos modelos que dependem dessa informação;
* atualização do `publico_alvo` e do `eventos` para usar `data_fim_efetiva` como marco de início do puerpério, garantindo coerência entre a janela do puerpério e a data efetivamente adotada pelo modelo de gestações;
* simplificação da classificação de consultas no `eventos`, removendo a categoria geral e mantendo apenas consultas realizadas por médico ou enfermeiro sob o tipo `Consulta`, que é o conceito efetivamente utilizado pelos protocolos;
* ampliação da regra de visita domiciliar para incluir também atendimentos realizados por Técnico de Agente Comunitário (`CBO 322255`), além de ACS;
* limpeza do CPF no `raw_prontuario_vitacare__atendimento`, para padronizar esse identificador desde a base e evitar inconsistências nos joins downstream.