### PR TITLE
[monitora cancer] add pregnancy indicator; implement exclusion criteria; change severity score; etc

### DIFF
--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
@@ -36,6 +36,7 @@ with
             pop.telefone,
             pop.clinica_sf_telefone as telefone_cf,
             pop.equipe_sf_telefone as telefone_esf,
+            pop.gestante,
 
             -- dados evento
             fcts.sistema_origem as fonte,
@@ -207,6 +208,7 @@ select
     ev.telefone,
     ev.telefone_cf,
     ev.telefone_esf,
+    ev.gestante,
 
     ev.fonte,
     ev.tipo,

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
@@ -1,11 +1,12 @@
 -- noqa: disable=LT08
 
 -- Eventos de monitoramento de câncer de mama em forma longa, com janelas
--- temporais (dias_proximo_evento) e agregados por paciente (tempo_total,
--- gravidade_score) broadcast em cada linha.
+-- temporais (dias_proximo_evento), identificador de episódio (run_id) e
+-- agregado por paciente (tempo_total) broadcast em cada linha.
 --
 -- Episódios ("runs"): sequências consecutivas de eventos cujos gaps entre
 -- data_referencia_evento não excedem `episodio_gap_dias` (default 180 dias).
+-- O run_id incrementa a cada gap > episodio_gap_dias dentro do mesmo paciente.
 --
 -- tempo_total:
 --   - pacientes com SER: dias do início da run que contém o primeiro SER até
@@ -59,6 +60,7 @@ with
             fcts.data_exame_resultado as data_resultado,
             fcts.mama_esquerda_resultado,
             fcts.mama_direita_resultado,
+            fcts.criterio_diagnostico,
             fcts.evento_status,
             (
                 select max(d)
@@ -154,8 +156,7 @@ with
         select
             cpf_particao,
             data_referencia_evento as ultima_data_referencia,
-            run_id as ultimo_run_id,
-            date_diff(current_date('America/Sao_Paulo'), data_referencia_evento, day) as gravidade_score
+            run_id as ultimo_run_id
         from eventos_com_run
             qualify row_number() over evento_order_desc = 1
             window evento_order_desc as (
@@ -222,15 +223,16 @@ select
     ev.data_autorizacao,
     ev.data_execucao,
     ev.data_resultado,
+    ev.data_referencia_evento,
 
     ev.mama_esquerda_resultado,
     ev.mama_direita_resultado,
+    ev.criterio_diagnostico,
 
     ev.dias_proximo_evento,
+    ev.run_id,
 
-    ttp.tempo_total,
-    uep.gravidade_score
+    ttp.tempo_total
 
-from eventos_com_janela as ev
+from eventos_com_run as ev
     left join tempo_total_por_paciente as ttp using (cpf_particao)
-    left join ultimo_evento_por_paciente as uep using (cpf_particao)

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
@@ -124,6 +124,11 @@ with
             )
     ),
 
+    -- "Início" da run = data de solicitação do primeiro evento da sequência.
+    -- A sequência (run) é definida pelas fronteiras em data_referencia_evento
+    -- (gaps > episodio_gap_dias quebram a run); aqui usamos a data_solicitacao
+    -- mais antiga dentro da run como marcador de quando a paciente entrou
+    -- naquele percurso de cuidado.
     run_starts as (
         select
             cpf_particao,

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__exclusoes.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__exclusoes.sql
@@ -1,0 +1,229 @@
+-- noqa: disable=LT08
+
+-- Regras de EXCLUSÃO da população-alvo do monitoramento de câncer de mama,
+-- derivadas do histórico de eventos em mart_monitora_cancer__fatos.
+--
+-- Granularidade: 1 linha por paciente_cpf excluído, com um array dos motivos
+-- aplicáveis (um paciente pode satisfazer mais de uma regra ao mesmo tempo).
+--
+-- A regra de óbito (cadastral) é aplicada na entrada do funil, em
+-- int_monitora_cancer__populacao_alvo; aqui ficam SOMENTE regras derivadas
+-- de eventos.
+--
+-- Estrutura do modelo (lê-se de cima para baixo como uma narrativa):
+--
+--   1. eventos              → um registro por evento do paciente, com a
+--                             "data de referência" (máx entre as datas)
+--                             e o ranking de recência (1 = mais recente).
+--
+--   2. eventos_com_sinais   → para cada evento, calcula flags booleanas
+--                             auto-explicativas (eh_mamografia,
+--                             resultados_em_cat_3, sem_lesao, etc.).
+--                             Toda a complexidade sintática mora aqui.
+--
+--   3. ultimo / penultimo   → pega os 2 eventos mais recentes por paciente.
+--
+--   4. motivos              → aplica as regras: cada regra é uma única
+--                             linha de WHERE em cima das flags prontas,
+--                             fácil de auditar.
+--
+-- Regras implementadas:
+--   (ii)  MAMOGRAFIA_BIRADS_1_OU_2       — último = mamografia Cat 1/2.
+--   (iii) MAMOGRAFIA_BIRADS_3_EM_DOIS    — últimos 2 = mamografia Cat 3.
+--   (iv)  BIOPSIA_SEM_LESAO              — último = biópsia sem lesão.
+--   (v)   SER_ANTIGO                     — último = SER há ≥ N meses.
+
+-- Janela, em meses, usada na regra (v). Parametrizado via var do dbt.
+{% set exclusao_ser_meses = var('exclusao_ser_meses', 6) %}
+
+
+with
+    -- ── 1. Eventos com data de referência e ranking por recência ────────────
+    eventos as (
+        select
+            paciente_cpf,
+            sistema_origem,
+            procedimento,
+            mama_esquerda_resultado,
+            mama_direita_resultado,
+
+            data_solicitacao,
+            data_autorizacao,
+            data_execucao,
+            data_exame_resultado,
+
+            -- "data_referencia_evento" = a data mais recente entre as
+            -- disponíveis (mesmo critério usado em eventos_episodios).
+            (
+                select max(d)
+                from unnest ([
+                    data_solicitacao,
+                    data_autorizacao,
+                    data_execucao,
+                    data_exame_resultado
+                ]) as d
+            ) as data_referencia_evento
+        from {{ ref("mart_monitora_cancer__fatos") }}
+        where paciente_cpf is not null
+    ),
+
+    eventos_ranqueados as (
+        select
+            *,
+            -- recencia = 1 é o evento MAIS recente, 2 é o penúltimo, etc.
+            row_number() over (
+                partition by paciente_cpf
+                -- mesma ordem canônica usada nos outros modelos do projeto,
+                -- só que descendente para pegar os mais recentes primeiro.
+                order by
+                    data_referencia_evento desc,
+                    data_solicitacao desc,
+                    data_autorizacao desc,
+                    data_execucao desc,
+                    data_exame_resultado desc
+            ) as recencia
+        from eventos
+    ),
+
+    -- ── 2. Sinais por evento ────────────────────────────────────────────────
+    -- Cada flag abaixo responde a uma pergunta clínica simples em TRUE/FALSE.
+    -- Toda a complexidade (prefixos BI-RADS, nulls nas mamas, etc.) fica
+    -- encapsulada aqui; as regras lá embaixo só consultam as flags.
+    eventos_com_sinais as (
+        select
+            paciente_cpf,
+            recencia,
+            data_referencia_evento,
+
+            -- Que TIPO de evento é este?
+            sistema_origem = 'SISCAN'
+            and procedimento in (
+                'RESULTADO MAMOGRAFIA DE RASTREIO',
+                'RESULTADO MAMOGRAFIA DIAGNOSTICA'
+            ) as eh_mamografia,
+
+            sistema_origem = 'SISCAN'
+            and procedimento not in (
+                'RESULTADO MAMOGRAFIA DE RASTREIO',
+                'RESULTADO MAMOGRAFIA DIAGNOSTICA'
+            ) as eh_biopsia,
+
+            sistema_origem = 'SER' as eh_ser,
+
+            -- QUE RESULTADO a mamografia trouxe?
+            -- "Todos os resultados preenchidos estão em Cat 1 ou 2"
+            -- (ao menos uma mama precisa ter resultado).
+            (
+                mama_esquerda_resultado is not null
+                or mama_direita_resultado is not null
+            )
+            and (
+                mama_esquerda_resultado is null
+                or starts_with(mama_esquerda_resultado, 'Categoria 1')
+                or starts_with(mama_esquerda_resultado, 'Categoria 2')
+            )
+            and (
+                mama_direita_resultado is null
+                or starts_with(mama_direita_resultado, 'Categoria 1')
+                or starts_with(mama_direita_resultado, 'Categoria 2')
+            ) as resultados_em_cat_1_ou_2,
+
+            -- "Todos os resultados preenchidos estão em Cat 3"
+            (
+                mama_esquerda_resultado is not null
+                or mama_direita_resultado is not null
+            )
+            and (
+                mama_esquerda_resultado is null
+                or starts_with(mama_esquerda_resultado, 'Categoria 3')
+            )
+            and (
+                mama_direita_resultado is null
+                or starts_with(mama_direita_resultado, 'Categoria 3')
+            ) as resultados_em_cat_3,
+
+            -- Biópsia SEM conclusão anátomo-patológica em nenhum lado.
+            -- (em int_monitora_cancer__siscan_histo_mama, mama_{lado}_resultado
+            -- = COALESCE(lesao_neoplasico, lesao_benigno) — NULL em ambos
+            -- significa "nem neoplásica nem benigna").
+            mama_esquerda_resultado is null
+            and mama_direita_resultado is null as sem_lesao,
+
+            -- Evento com data de referência há {{ exclusao_ser_meses }} meses ou mais.
+            data_referencia_evento <= date_sub(
+                current_date('America/Sao_Paulo'),
+                interval {{ exclusao_ser_meses }} month
+            ) as evento_antigo
+        from eventos_ranqueados
+    ),
+
+    -- ── 3. Dois eventos mais recentes, separados ────────────────────────────
+    ultimo as (
+        select * from eventos_com_sinais where recencia = 1
+    ),
+
+    penultimo as (
+        select * from eventos_com_sinais where recencia = 2
+    ),
+
+    -- ── 4. Regras ───────────────────────────────────────────────────────────
+    -- Cada regra vira um WHERE direto sobre as flags. Leia em português:
+    --   "o último evento é mamografia E os resultados estão em Cat 1 ou 2".
+    motivos as (
+
+        -- (ii) último evento = mamografia com todos resultados em Cat 1 ou 2
+        select
+            paciente_cpf,
+            'MAMOGRAFIA_BIRADS_1_OU_2' as motivo_exclusao
+        from ultimo
+        where eh_mamografia
+            and resultados_em_cat_1_ou_2
+
+        union all
+
+        -- (iii) os DOIS últimos eventos foram mamografia com Cat 3 em cada
+        select
+            u.paciente_cpf,
+            'MAMOGRAFIA_BIRADS_3_EM_DOIS' as motivo_exclusao
+        from ultimo as u
+            join penultimo as p using (paciente_cpf)
+        where u.eh_mamografia
+            and u.resultados_em_cat_3
+            and p.eh_mamografia
+            and p.resultados_em_cat_3
+
+        union all
+
+        -- (iv) último evento = biópsia sem lesão neoplásica nem benigna
+        select
+            paciente_cpf,
+            'BIOPSIA_SEM_LESAO' as motivo_exclusao
+        from ultimo
+        where eh_biopsia
+            and sem_lesao
+
+        union all
+
+        -- (v) último evento = SER há {{ exclusao_ser_meses }} meses ou mais.
+        --
+        -- TODO: refinar por evento_status quando SER ambulatorial expuser
+        -- essa coluna (hoje NULL). A regra-alvo é:
+        --   • 'chegada confirmada' / 'cancelada' → excluir após 6 meses
+        --   • 'alta'                            → excluir após 3 meses
+        --   • demais status                     → NÃO excluir
+        select
+            paciente_cpf,
+            'SER_ANTIGO' as motivo_exclusao
+        from ultimo
+        where eh_ser
+            and evento_antigo
+    )
+
+select
+    paciente_cpf,
+    array_agg(
+        distinct motivo_exclusao
+        order by motivo_exclusao
+    ) as motivos_exclusao
+from motivos
+group by paciente_cpf

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__gravidade.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__gravidade.sql
@@ -1,0 +1,238 @@
+-- noqa: disable=LT08
+
+-- Score de gravidade da paciente no monitoramento de câncer de mama.
+--
+-- Conceito: para cada par (trigger, expected, threshold) — chamado "subscore" —
+-- conta-se quantos dias o desfecho esperado atrasou para acontecer após o
+-- evento gatilho, descontando a folga do threshold:
+--
+--   dias_atraso = max(0, date_diff(expected_date_ou_hoje, trigger_date) - threshold)
+--
+-- O gravidade_score do paciente é a SOMA das parcelas de todos os triggers
+-- de todos os subscores, multiplicada por 2 se a paciente for gestante.
+--
+-- Escopo temporal: apenas eventos do RUN ATUAL (último episódio) entram no
+-- cálculo. Eventos de runs antigos (separados por > episodio_gap_dias)
+-- representam ciclos de cuidado encerrados e não inflam o score atual.
+--
+-- Convenções:
+--   trigger_date  = data_referencia_evento (= MAX das 4 datas do evento)
+--   expected_date = COALESCE(data_execucao, data_autorizacao)
+--                   (eventos só com data_solicitacao ainda na fila NÃO contam)
+--
+-- Subscores atuais:
+--   1) SISCAN mamografia Cat 0/4/5  →  SISREG ultra/biópsia,  threshold 10 dias
+--   2) SISCAN mamografia Cat 6      →  qualquer evento SER,   threshold  5 dias
+--   3) SISCAN biópsia neoplásica    →  qualquer evento SER,   threshold  5 dias
+--
+-- Para adicionar um subscore: criar mais um par de CTEs `subscore_N_triggers`
+-- + `subscore_N` no padrão abaixo e incluir no UNION ALL de `todos_atrasos`.
+-- Subscores intra-evento (mesmo evento de origem para trigger e expected)
+-- usam evento_id como chave de JOIN em vez de cpf_particao + faixa de data.
+
+with
+    -- Eventos do RUN ATUAL apenas, com a data_expected pré-calculada.
+    eventos_run_atual as (
+        select
+            cpf_particao,
+            fonte,
+            procedimento,
+            criterio_diagnostico,
+            mama_esquerda_resultado,
+            mama_direita_resultado,
+            data_referencia_evento,
+            coalesce(data_execucao, data_autorizacao) as data_expected,
+            gestante
+        from {{ ref("int_monitora_cancer__eventos_episodios") }}
+        qualify run_id = max(run_id) over (partition by cpf_particao)
+    ),
+
+    -- ── Subscore 1: SISCAN mama Cat 0/4/5 → SISREG ultra/biópsia, threshold 10 ──
+    subscore_1_triggers as (
+        select
+            cpf_particao,
+            data_referencia_evento as data_trigger
+        from eventos_run_atual
+        where fonte = 'SISCAN'
+            and procedimento in (
+                'RESULTADO MAMOGRAFIA DE RASTREIO',
+                'RESULTADO MAMOGRAFIA DIAGNOSTICA'
+            )
+            and (
+                starts_with(coalesce(mama_esquerda_resultado, ''), 'Categoria 0')
+                or starts_with(coalesce(mama_esquerda_resultado, ''), 'Categoria 4')
+                or starts_with(coalesce(mama_esquerda_resultado, ''), 'Categoria 5')
+                or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 0')
+                or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 4')
+                or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 5')
+            )
+    ),
+
+    subscore_1_expected as (
+        -- procedimento já vem normalizado por clean_proced_name em fatos
+        -- (uppercase, sem diacríticos), então 'BIOPSIA' cobre 'BIÓPSIA' e
+        -- 'ULTRA' cobre 'ULTRASSONOGRAFIA' e 'ULTRA-SONOGRAFIA'
+        select
+            cpf_particao,
+            data_expected
+        from eventos_run_atual
+        where fonte = 'SISREG'
+            and (
+                contains_substr(procedimento, 'ULTRA')
+                or contains_substr(procedimento, 'BIOPSIA')
+            )
+            and data_expected is not null
+    ),
+
+    subscore_1 as (
+        select
+            t.cpf_particao,
+            'SISCAN_MAMA_CAT_0_4_5__SISREG_ULTRA_OU_BIOPSIA' as subscore,
+            t.data_trigger,
+            min(e.data_expected) as data_expected,
+            greatest(
+                0,
+                date_diff(
+                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
+                    t.data_trigger,
+                    day
+                ) - 10
+            ) as dias_atraso
+        from subscore_1_triggers as t
+            left join subscore_1_expected as e
+            on t.cpf_particao = e.cpf_particao
+                and e.data_expected >= t.data_trigger
+        group by t.cpf_particao, t.data_trigger
+    ),
+
+    -- Expecteds compartilhados pelos subscores 2 e 3: qualquer evento SER.
+    expected_ser as (
+        select
+            cpf_particao,
+            data_expected
+        from eventos_run_atual
+        where fonte = 'SER'
+            and data_expected is not null
+    ),
+
+    -- ── Subscore 2: SISCAN mama Cat 6 → qualquer SER, threshold 5 ──
+    subscore_2_triggers as (
+        select
+            cpf_particao,
+            data_referencia_evento as data_trigger
+        from eventos_run_atual
+        where fonte = 'SISCAN'
+            and procedimento in (
+                'RESULTADO MAMOGRAFIA DE RASTREIO',
+                'RESULTADO MAMOGRAFIA DIAGNOSTICA'
+            )
+            and (
+                starts_with(coalesce(mama_esquerda_resultado, ''), 'Categoria 6')
+                or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 6')
+            )
+    ),
+
+    subscore_2 as (
+        select
+            t.cpf_particao,
+            'SISCAN_MAMA_CAT_6__SER' as subscore,
+            t.data_trigger,
+            min(e.data_expected) as data_expected,
+            greatest(
+                0,
+                date_diff(
+                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
+                    t.data_trigger,
+                    day
+                ) - 5
+            ) as dias_atraso
+        from subscore_2_triggers as t
+            left join expected_ser as e
+            on t.cpf_particao = e.cpf_particao
+                and e.data_expected >= t.data_trigger
+        group by t.cpf_particao, t.data_trigger
+    ),
+
+    -- ── Subscore 3: SISCAN biópsia neoplásica → qualquer SER, threshold 5 ──
+    -- criterio_diagnostico em laudos histopatológicos = (lesao_neoplasico is not null),
+    -- então o filtro abaixo é equivalente exato a "biópsia com lesão neoplásica".
+    subscore_3_triggers as (
+        select
+            cpf_particao,
+            data_referencia_evento as data_trigger
+        from eventos_run_atual
+        where fonte = 'SISCAN'
+            and procedimento not in (
+                'RESULTADO MAMOGRAFIA DE RASTREIO',
+                'RESULTADO MAMOGRAFIA DIAGNOSTICA'
+            )
+            and criterio_diagnostico = true
+    ),
+
+    subscore_3 as (
+        select
+            t.cpf_particao,
+            'SISCAN_BIOPSIA_NEOPLASICA__SER' as subscore,
+            t.data_trigger,
+            min(e.data_expected) as data_expected,
+            greatest(
+                0,
+                date_diff(
+                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
+                    t.data_trigger,
+                    day
+                ) - 5
+            ) as dias_atraso
+        from subscore_3_triggers as t
+            left join expected_ser as e
+            on t.cpf_particao = e.cpf_particao
+                and e.data_expected >= t.data_trigger
+        group by t.cpf_particao, t.data_trigger
+    ),
+
+    todos_atrasos as (
+        select * from subscore_1
+        union all
+        select * from subscore_2
+        union all
+        select * from subscore_3
+    ),
+
+    agregado as (
+        select
+            cpf_particao,
+            sum(dias_atraso) as gravidade_score_base,
+            array_agg(
+                struct(
+                    subscore,
+                    data_trigger,
+                    data_expected,
+                    dias_atraso
+                )
+                order by data_trigger desc, subscore
+            ) as gravidade_breakdown
+        from todos_atrasos
+        group by cpf_particao
+    ),
+
+    -- gestante já vem propagado em cada linha de eventos_episodios; qualquer
+    -- linha do paciente serve. distinct para colapsar.
+    gestantes as (
+        select distinct
+            cpf_particao,
+            gestante
+        from eventos_run_atual
+    )
+
+select
+    a.cpf_particao,
+    if(
+        coalesce(g.gestante, false),
+        a.gravidade_score_base * 2,
+        a.gravidade_score_base
+    ) as gravidade_score,
+    a.gravidade_score_base,
+    coalesce(g.gestante, false) as gestante,
+    a.gravidade_breakdown
+from agregado as a
+    left join gestantes as g using (cpf_particao)

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__populacao_alvo.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__populacao_alvo.sql
@@ -5,6 +5,15 @@
 -- com dados cadastrais (nome, idade, raça/cor, telefone) e de vínculo APS
 -- (clínica, equipe, telefones institucionais).
 -- Granularidade: 1 linha por paciente_cpf.
+--
+-- Regras de exclusão aplicadas aqui:
+--   (i) Óbito (cadastral): filtro direto via bcadastro.obito_ano IS NULL e
+--       dim_paciente.anos_obito (fonte de verdade: bcadastro → HCI).
+--   (ii)-(v) Exclusões derivadas do histórico de eventos (último evento
+--       mamografia Cat 1/2, duas mamografias Cat 3, biópsia sem lesão, SER
+--       antigo) são centralizadas em int_monitora_cancer__exclusoes e
+--       aplicadas abaixo via anti-join. Consulte aquele modelo para a
+--       documentação completa de cada regra.
 
 with
     populacao_interesse as (
@@ -69,29 +78,28 @@ select
 
     -- vínculo APS sempre vem do HCI (cadastro consolidado da APS). pacientes que
     -- não estão no HCI ficam com esses campos NULL. todos os campos vêm do MESMO
-    -- registro do HCI — elimina o desalinhamento do SAFE_OFFSET(0) anterior entre
-    -- arrays paralelos.
-dim_paciente.clinica_sf as clinica_sf,
-dim_paciente.clinica_sf_ap as clinica_sf_ap,
-dim_paciente.clinica_sf_telefone as clinica_sf_telefone,
-dim_paciente.equipe_sf as equipe_sf,
-dim_paciente.equipe_sf_telefone as equipe_sf_telefone,
+    -- registro do HCI
+    dim_paciente.clinica_sf as clinica_sf,
+    dim_paciente.clinica_sf_ap as clinica_sf_ap,
+    dim_paciente.clinica_sf_telefone as clinica_sf_telefone,
+    dim_paciente.equipe_sf as equipe_sf,
+    dim_paciente.equipe_sf_telefone as equipe_sf_telefone,
 
     gest.cpf is not null as gestante
 
 from populacao_interesse as pop
 
-    left join {{ref("pacientes_subgeral__dim_paciente")}} as dim_paciente
-    on pop.paciente_cpf = dim_paciente.cpf_particao
+left join {{ref("pacientes_subgeral__dim_paciente")}} as dim_paciente
+on pop.paciente_cpf = dim_paciente.cpf_particao
 
-    left join {{ref("mart_iplanrio__telefones_validos")}} as telefones
-    on pop.paciente_cpf = safe_cast(telefones.cpf as int)
+left join {{ref("mart_iplanrio__telefones_validos")}} as telefones
+on pop.paciente_cpf = safe_cast(telefones.cpf as int)
 
-    left join {{ref("raw_bcadastro__cpf")}} as bcadastro
-    on pop.paciente_cpf = bcadastro.cpf_particao
+left join {{ref("raw_bcadastro__cpf")}} as bcadastro
+on pop.paciente_cpf = bcadastro.cpf_particao
 
-    left join gestantes_ativas as gest
-    on lpad(safe_cast(pop.paciente_cpf as string), 11, '0') = gest.cpf
+left join gestantes_ativas as gest
+on lpad(safe_cast(pop.paciente_cpf as string), 11, '0') = gest.cpf
 
 where bcadastro.sexo != "masculino"
     and bcadastro.obito_ano is null
@@ -99,4 +107,11 @@ where bcadastro.sexo != "masculino"
         select 1
         from unnest (dim_paciente.anos_obito) as ano
         where ano is not null
+    )
+    -- anti-join: o paciente permanece na população-alvo somente
+    -- se não existir um registro correspondente em int_monitora_cancer__exclusoes
+    and not exists(
+        select 1
+        from {{ ref("int_monitora_cancer__exclusoes") }} as excl
+        where excl.paciente_cpf = pop.paciente_cpf
     )

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__populacao_alvo.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__populacao_alvo.sql
@@ -23,6 +23,12 @@ with
                 or criterio_diagnostico = true
             )
         group by paciente_cpf
+    ),
+
+    gestantes_ativas as (
+        select distinct cpf
+        from {{ ref("mart_bi_gestacoes__gestacoes") }}
+        where fase_atual = 'Gestação'
     )
 
 select
@@ -69,7 +75,9 @@ dim_paciente.clinica_sf as clinica_sf,
 dim_paciente.clinica_sf_ap as clinica_sf_ap,
 dim_paciente.clinica_sf_telefone as clinica_sf_telefone,
 dim_paciente.equipe_sf as equipe_sf,
-dim_paciente.equipe_sf_telefone as equipe_sf_telefone
+dim_paciente.equipe_sf_telefone as equipe_sf_telefone,
+
+    gest.cpf is not null as gestante
 
 from populacao_interesse as pop
 
@@ -81,6 +89,9 @@ from populacao_interesse as pop
 
     left join {{ref("raw_bcadastro__cpf")}} as bcadastro
     on pop.paciente_cpf = bcadastro.cpf_particao
+
+    left join gestantes_ativas as gest
+    on lpad(safe_cast(pop.paciente_cpf as string), 11, '0') = gest.cpf
 
 where bcadastro.sexo != "masculino"
     and bcadastro.obito_ano is null

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -224,11 +224,11 @@ models:
 
       - name: tempo_total
         description: >
-          Tempo, em dias, de percurso da paciente até a regulação oncológica:
-          para pacientes com SER, vai do início do episódio (sequência de
-          eventos) que contém o primeiro SER até a data desse primeiro SER;
-          para pacientes sem SER, vai do início do último episódio até a data
-          atual. Retorna NULL quando o cálculo resulta em zero.
+          Tempo, em dias, de percurso da paciente até a entrada em UNACON
+          através do SER. Caso a paciente não tenha entrado, o cálculo é
+          feito até o dia atual. A data do início do percurso é a data de
+          solicitação do primeiro evento em uma sequência de eventos com
+          intervalo entre eles menor ou igual a 180 dias.
 
       - name: gestante
         description: >
@@ -258,6 +258,21 @@ models:
           eventos registrados. Campos: siscan (exames), ser (regulação
           oncológica), sisreg (regulação ambulatorial).
 
+      - name: fontes.siscan
+        description: >
+          TRUE quando a paciente possui ao menos um evento originado do SISCAN
+          (laudos radiológicos ou histopatológicos de mama).
+
+      - name: fontes.ser
+        description: >
+          TRUE quando a paciente possui ao menos um evento originado do SER
+          (regulação estadual ambulatorial ou internações em oncologia).
+
+      - name: fontes.sisreg
+        description: >
+          TRUE quando a paciente possui ao menos um evento originado do SISREG
+          (regulação ambulatorial municipal).
+
       # ── eventos ───────────────────────────────────────────────────────────────
       - name: eventos
         description: >
@@ -265,8 +280,92 @@ models:
           antigo ao mais recente. Cada struct contém: sistema de origem (fonte),
           tipo de evento, status, procedimento, CID, unidade solicitante,
           unidade executante, datas (solicitação, autorização, execução,
-          resultado) em formato date e string, resultados dos exames das mamas
-          e o intervalo em dias até o próximo evento (dias_proximo_evento).
+          resultado) em formato date e string, resultados dos exames das mamas,
+          o intervalo em dias até o próximo evento (dias_proximo_evento) e o
+          identificador do episódio (jornada_id) ao qual o evento pertence —
+          episódios são sequências consecutivas de eventos cujos gaps entre
+          data_referencia_evento não excedem 180 dias; o id incrementa a cada
+          gap maior, dentro de um mesmo paciente.
+
+      - name: eventos.fonte
+        description: Sistema de origem do evento (SISREG, SER ou SISCAN).
+
+      - name: eventos.tipo
+        description: >
+          Classificação funcional do sistema de origem do evento
+          (REGULACAO ou EXAME).
+
+      - name: eventos.evento_status
+        description: >
+          Status do evento no sistema de origem (ex.: AGENDADO, AUTORIZADO,
+          CANCELADO, EXECUTADO).
+
+      - name: eventos.procedimento
+        description: Descrição padronizada do procedimento solicitado ou executado.
+
+      - name: eventos.cid
+        description: Código CID-10 (3 caracteres) associado ao evento.
+
+      - name: eventos.unidade_solicitante
+        description: >
+          Unidade de saúde que solicitou o evento, no formato
+          "<CNES> - <nome do estabelecimento>". Quando o CNES ou o nome não
+          estão disponíveis, é utilizado o texto "CNES ?" ou
+          "Estabelecimento não identificado", respectivamente.
+
+      - name: eventos.unidade_executante
+        description: >
+          Unidade de saúde que executou (ou executará) o evento, no formato
+          "<CNES> - <nome do estabelecimento>". Mesmas regras de preenchimento
+          de unidade_solicitante quando há campos ausentes.
+
+      - name: eventos.data_solicitacao
+        description: Data em que o evento foi solicitado, em formato date.
+
+      - name: eventos.data_autorizacao
+        description: Data em que o evento foi autorizado ou agendado, em formato date.
+
+      - name: eventos.data_execucao
+        description: Data em que o evento foi efetivamente executado, em formato date.
+
+      - name: eventos.data_resultado
+        description: >
+          Data de liberação do laudo/resultado do evento, em formato date
+          (aplicável a laudos do SISCAN).
+
+      - name: eventos.data_solicitacao_str
+        description: >
+          Mesmo valor de eventos.data_solicitacao, convertido para string
+          (útil em ferramentas que não preservam o tipo date no consumo).
+
+      - name: eventos.data_autorizacao_str
+        description: Mesmo valor de eventos.data_autorizacao, convertido para string.
+
+      - name: eventos.data_execucao_str
+        description: Mesmo valor de eventos.data_execucao, convertido para string.
+
+      - name: eventos.data_resultado_str
+        description: Mesmo valor de eventos.data_resultado, convertido para string.
+
+      - name: eventos.resultados
+        description: >
+          Array de strings com os resultados dos exames de mama no formato
+          "Mama Esquerda <resultado>" e/ou "Mama Direita <resultado>". Vazio
+          quando o evento não produz laudo de mama.
+
+      - name: eventos.dias_proximo_evento
+        description: >
+          Intervalo, em dias, entre a data de referência deste evento
+          (MAX das datas de solicitação, autorização, execução e resultado) e
+          a data de referência do próximo evento cronológico da mesma paciente.
+          NULL no último evento da paciente.
+
+      - name: eventos.jornada_id
+        description: >
+          Identificador do episódio de cuidado (jornada) ao qual o evento
+          pertence. Episódios são sequências consecutivas de eventos da mesma
+          paciente cujo intervalo entre datas de referência não excede 180
+          dias; o id incrementa a cada gap maior, reiniciando por paciente.
 
   - name: mart_monitora_cancer__gravidade
     description: >

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -225,6 +225,12 @@ models:
           para pacientes sem SER, vai do início do último episódio até a data
           atual. Retorna NULL quando o cálculo resulta em zero.
 
+      - name: gestante
+        description: >
+          TRUE quando a paciente está atualmente gestante segundo
+          mart_bi_gestacoes__gestacoes (fase_atual = 'Gestação'); FALSE caso
+          contrário.
+
       # ── contato ───────────────────────────────────────────────────────────────
       - name: telefone
         description: >

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -212,9 +212,14 @@ models:
 
       - name: gravidade_score
         description: >
-          Número de dias entre a data de referência do último evento da
-          paciente e a data atual. Valores maiores indicam pacientes sem
-          movimentação recente e, portanto, potencialmente mais críticas de
+          Soma de "dias de atraso" da paciente, calculada em
+          mart_monitora_cancer__gravidade. Para cada subscore (par
+          trigger/expected/threshold), conta-se quantos dias o desfecho
+          esperado atrasou após o evento gatilho, descontando a folga do
+          threshold. O total é multiplicado por 2 quando a paciente é
+          gestante. Pacientes sem nenhum trigger no run atual recebem 0.
+          Valores maiores indicam pacientes com mais atrasos acumulados na
+          linha de cuidado e, portanto, potencialmente mais críticas de
           acompanhar.
 
       - name: tempo_total
@@ -262,3 +267,70 @@ models:
           unidade executante, datas (solicitação, autorização, execução,
           resultado) em formato date e string, resultados dos exames das mamas
           e o intervalo em dias até o próximo evento (dias_proximo_evento).
+
+  - name: mart_monitora_cancer__gravidade
+    description: >
+      Score de gravidade da paciente no monitoramento de câncer de mama,
+      calculado como a soma dos "dias de atraso" entre cada evento gatilho
+      (trigger) e o respectivo desfecho esperado (expected outcome) — descontada
+      a folga do threshold de cada subscore — multiplicada por 2 se a paciente
+      for gestante. Considera apenas eventos do RUN ATUAL (último episódio de
+      cuidado) de cada paciente.
+
+      Subscores atualmente implementados:
+        1. SISCAN mamografia Cat 0/4/5 → SISREG ultrassonografia ou biópsia,
+           threshold 10 dias.
+        2. SISCAN mamografia Cat 6 → qualquer evento SER, threshold 5 dias.
+        3. SISCAN biópsia neoplásica → qualquer evento SER, threshold 5 dias.
+
+      Convenções de data: trigger_date = data_referencia_evento (MAX das 4
+      datas do evento); expected_date = COALESCE(data_execucao, data_autorizacao).
+      Eventos esperados ainda só com data_solicitacao não zeram o atraso.
+
+      Granularidade: 1 linha por paciente (cpf_particao). Apenas pacientes
+      com pelo menos um trigger no run atual estão presentes.
+    meta:
+      owner: "SMS/SUBGERAL/CR/NTI"
+
+    columns:
+      - name: cpf_particao
+        description: >
+          CPF da paciente em formato numérico (int64). Chave primária e
+          campo de particionamento da tabela.
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
+        data_tests:
+          - unique:
+              name: mart_monitora_cancer__gravidade__cpf_particao__unique
+          - not_null:
+              name: mart_monitora_cancer__gravidade__cpf_particao__not_null
+
+      - name: gravidade_score
+        description: >
+          Score final, em "dias de atraso", já com o multiplicador de gestante
+          aplicado. Igual a gravidade_score_base * 2 quando gestante = TRUE,
+          caso contrário igual a gravidade_score_base.
+        data_tests:
+          - not_null:
+              name: mart_monitora_cancer__gravidade__gravidade_score__not_null
+
+      - name: gravidade_score_base
+        description: >
+          Soma das parcelas de dias_atraso de todos os subscores, ANTES da
+          multiplicação por gestante. Útil para auditoria e comparação direta
+          entre pacientes gestantes e não-gestantes.
+
+      - name: gestante
+        description: >
+          TRUE quando a paciente está atualmente gestante (mesma fonte usada
+          em mart_monitora_cancer__pacientes_linha_tempo). Aciona o
+          multiplicador 2x sobre gravidade_score_base.
+
+      - name: gravidade_breakdown
+        description: >
+          Array de structs detalhando cada parcela do score, ordenado por
+          data_trigger desc. Cada struct contém: subscore (identificador
+          textual do par trigger/expected), data_trigger (data de referência
+          do evento gatilho), data_expected (data de execução/autorização do
+          desfecho esperado encontrado, ou NULL quando ainda não aconteceu)
+          e dias_atraso (parcela contribuída por aquele trigger ao score).

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__gravidade.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__gravidade.sql
@@ -1,0 +1,23 @@
+-- noqa: disable=LT08
+
+{{
+  config(
+    schema="projeto_monitora_cancer",
+    alias="gravidade",
+    partition_by={
+        "field": "cpf_particao",
+        "data_type": "int64",
+        "range": {"start": 0, "end": 100000000000, "interval": 34722222},
+    },
+    cluster_by=["cpf_particao"],
+    on_schema_change="sync_all_columns"
+  )
+}}
+
+select
+    cpf_particao,
+    gravidade_score,
+    gravidade_score_base,
+    gestante,
+    gravidade_breakdown
+from {{ ref("int_monitora_cancer__gravidade") }}

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -79,7 +79,8 @@ select
                 )
             ) as resultados,
 
-            ev.dias_proximo_evento
+            ev.dias_proximo_evento,
+            ev.run_id as jornada_id
         )
 
         order by

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -16,92 +16,94 @@ on_schema_change = 'sync_all_columns'
 
 select
     -- pk
-    cpf_particao,
-    cpf,
+    ev.cpf_particao,
+    ev.cpf,
 
     -- id paciente
-    nome,
-    raca_cor,
-    idade,
-    ap,
-    cf,
-    equipe_sf,
+    ev.nome,
+    ev.raca_cor,
+    ev.idade,
+    ev.ap,
+    ev.cf,
+    ev.equipe_sf,
 
     -- qualificadores gerais
-    status,
-    any_value (gravidade_score) as gravidade_score,
-    any_value (gestante) as gestante,
+    ev.status,
+    coalesce(any_value(grv.gravidade_score), 0) as gravidade_score,
+    any_value (ev.gestante) as gestante,
 
     -- contato paciente
-    telefone,
-    telefone_cf,
-    telefone_esf,
+    ev.telefone,
+    ev.telefone_cf,
+    ev.telefone_esf,
 
     -- sistemas com eventos do paciente
     struct(
-        logical_or(fonte = 'SISCAN') as siscan,
-        logical_or(fonte = 'SER') as ser,
-        logical_or(fonte = 'SISREG') as sisreg
+        logical_or(ev.fonte = 'SISCAN') as siscan,
+        logical_or(ev.fonte = 'SER') as ser,
+        logical_or(ev.fonte = 'SISREG') as sisreg
     ) as fontes,
 
     -- eventos
     array_agg (
         struct(
-            fonte,
-            tipo,
-            evento_status,
-            procedimento,
-            cid,
+            ev.fonte,
+            ev.tipo,
+            ev.evento_status,
+            ev.procedimento,
+            ev.cid,
 
-            unidade_solicitante,
-            unidade_executante,
+            ev.unidade_solicitante,
+            ev.unidade_executante,
 
-            data_solicitacao,
-            data_autorizacao,
-            data_execucao,
-            data_resultado,
+            ev.data_solicitacao,
+            ev.data_autorizacao,
+            ev.data_execucao,
+            ev.data_resultado,
 
-            safe_cast(data_solicitacao as string) as data_solicitacao_str,
-            safe_cast(data_autorizacao as string) as data_autorizacao_str,
-            safe_cast(data_execucao as string) as data_execucao_str,
-            safe_cast(data_resultado as string) as data_resultado_str,
+            safe_cast(ev.data_solicitacao as string) as data_solicitacao_str,
+            safe_cast(ev.data_autorizacao as string) as data_autorizacao_str,
+            safe_cast(ev.data_execucao as string) as data_execucao_str,
+            safe_cast(ev.data_resultado as string) as data_resultado_str,
 
             array_concat(
                 if(
-                    mama_esquerda_resultado is null,
+                    ev.mama_esquerda_resultado is null,
                     [],
-                    [concat("Mama Esquerda ", mama_esquerda_resultado)]
+                    [concat("Mama Esquerda ", ev.mama_esquerda_resultado)]
                 ),
                 if(
-                    mama_direita_resultado is null,
+                    ev.mama_direita_resultado is null,
                     [],
-                    [concat("Mama Direita ", mama_direita_resultado)]
+                    [concat("Mama Direita ", ev.mama_direita_resultado)]
                 )
             ) as resultados,
 
-            dias_proximo_evento
+            ev.dias_proximo_evento
         )
 
         order by
-            data_solicitacao,
-            data_autorizacao,
-            data_execucao,
-            data_resultado
+            ev.data_solicitacao,
+            ev.data_autorizacao,
+            ev.data_execucao,
+            ev.data_resultado
     ) as eventos,
 
-    any_value (tempo_total) as tempo_total
+    any_value (ev.tempo_total) as tempo_total
 
-from {{ ref("int_monitora_cancer__eventos_episodios") }}
+from {{ ref("int_monitora_cancer__eventos_episodios") }} as ev
+    left join {{ ref("mart_monitora_cancer__gravidade") }} as grv
+    on ev.cpf_particao = grv.cpf_particao
 group by
-    cpf_particao,
-    cpf,
-    nome,
-    raca_cor,
-    idade,
-    ap,
-    cf,
-    equipe_sf,
-    status,
-    telefone,
-    telefone_cf,
-    telefone_esf
+    ev.cpf_particao,
+    ev.cpf,
+    ev.nome,
+    ev.raca_cor,
+    ev.idade,
+    ev.ap,
+    ev.cf,
+    ev.equipe_sf,
+    ev.status,
+    ev.telefone,
+    ev.telefone_cf,
+    ev.telefone_esf

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -30,6 +30,7 @@ select
     -- qualificadores gerais
     status,
     any_value (gravidade_score) as gravidade_score,
+    any_value (gestante) as gestante,
 
     -- contato paciente
     telefone,

--- a/models/raw/siscan_web/_siscan_web__schema.yml
+++ b/models/raw/siscan_web/_siscan_web__schema.yml
@@ -230,9 +230,3 @@ models:
         quote: true
         data_tests:
           - not_null
-      - name: data_particao
-        description: Data utilizada para particionamento (Equivalente a data de realização do exame).
-        data_type: date
-        quote: true
-        data_tests:
-          - not_null

--- a/models/raw/siscan_web/raw_siscan_web__laudos.sql
+++ b/models/raw/siscan_web/raw_siscan_web__laudos.sql
@@ -8,7 +8,7 @@
     incremental_strategy='merge',
     unique_key='protocolo_id',
     partition_by={
-      "field": "data_particao",
+      "field": "data_solicitacao",
       "data_type": "date",
       "granularity": "month",
     },
@@ -325,7 +325,6 @@ with
 
                 -- metadados
                 parse_timestamp('%Y-%m-%d %H:%M:%E6S', data_extracao) as data_extracao,
-                parse_date('%d/%m/%Y', data_realizacao) as data_particao
 
             from source_norm
         )

--- a/models/raw/siscan_web/raw_siscan_web__laudos_histo_mama.sql
+++ b/models/raw/siscan_web/raw_siscan_web__laudos_histo_mama.sql
@@ -8,7 +8,7 @@
     incremental_strategy='merge',
     unique_key='protocolo_id',
     partition_by={
-      "field": "data_particao",
+      "field": "data_solicitacao",
       "data_type": "date",
       "granularity": "month",
     },
@@ -119,9 +119,7 @@ transformed as (
         {{ clean_name_string("profissional_responsavel_nome") }} as profissional_responsavel_nome,
 
         -- metadados
-        parse_timestamp('%Y-%m-%d %H:%M:%E6S', data_extracao) as data_extracao,
-        parse_date('%d/%m/%Y', data_realizacao) as data_particao
-
+        parse_timestamp('%Y-%m-%d %H:%M:%E6S', data_extracao) as data_extracao
     from source_norm
 )
 


### PR DESCRIPTION
Introduce a pregnancy indicator for patients and implement exclusion logic for those with positive results. Refactor the partition date for cost-saving in downstream models and add a new severity score along with an episodio_id in the mart schema. Adjust calculations for tempo_total based on the first data_solicitacao for specific runs.