### PR TITLE
Fix: incremental logic

### DIFF
--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__acto.sql
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__acto.sql
@@ -60,7 +60,7 @@ with
       safe_cast({{ process_null("json_extract_scalar(data,'$.consulta_realizada')") }} as boolean) as realizado,
       {{ process_null("json_extract_scalar(data,'$.saude_bucal[0].tipo_atendimento')") }} as tipo_atendimento,
       loaded_at,
-      date(datahora_fim_atendimento) as data_particao
+      date(loaded_at) as data_particao
     from bruto_atendimento
   )
 

--- a/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__acto.sql
+++ b/models/raw/prontuario_vitacare_api/raw_prontuario_vitacare_api__acto.sql
@@ -10,7 +10,9 @@
   }
 ) }}
 
-{% set last_partition = get_last_partition_date(this) %}
+{% set max_loaded_at %}
+  select max(loaded_at) from {{ this }}
+{% endset %}
 
 with
   bruto_atendimento as (
@@ -24,7 +26,7 @@ with
       data
     from {{ source("brutos_prontuario_vitacare_api_staging", "atendimento_continuo") }}
     {% if is_incremental() %}
-      WHERE DATE(datalake_loaded_at, 'America/Sao_Paulo') >= DATE('{{ last_partition }}')
+      where datalake_loaded_at >= ({{ max_loaded_at }})
     {% endif %}
     qualify row_number() over (partition by id_prontuario_global order by loaded_at desc) = 1
   ),


### PR DESCRIPTION
O modelo incremental comparava a data de recebimento do dado (`datalake_loaded_at`) com a última partição da tabela (`datahora_fim_atendimento`). Como existem atendimentos com data futura (ex: 2066), essa comparação quebrava o incremental — nenhum registro novo era processado.

A correção foi separar: a partição continua sendo por `datahora_fim_atendimento`, mas agora o controle incremental usa o `max(loaded_at)` da própria tabela, que é uma data gerada pela nossa extração e nunca vai ser futura.