### PR TITLE
[CNES] fix: make data_particao deterministic in core/rio/dims

### DIFF
--- a/models/intermediate/subgeral/monitora_reg/int_mva__carga_horaria_ambulatorial_mensal.sql
+++ b/models/intermediate/subgeral/monitora_reg/int_mva__carga_horaria_ambulatorial_mensal.sql
@@ -1,15 +1,10 @@
 -- carga horaria ambulatorial dos profissionais no cnes em unidades que oferecem vagas
 -- no sisreg
 with
-    -- seleciona a versão mais atual dos dados
+    -- mart_cnes_subgeral__profissionais_mrj_sus atualmente é materializado como table (overwrite
+    -- completo), portanto contém um único snapshot.
     versao_atual as (
-        select *
-        from {{ ref("mart_cnes_subgeral__profissionais_mrj_sus") }}
-        where
-            metadado__data_particao = (
-                select max(metadado__data_particao)
-                from {{ ref("mart_cnes_subgeral__profissionais_mrj_sus") }}
-            )
+        select * from {{ ref("mart_cnes_subgeral__profissionais_mrj_sus") }}
     ),
 
     -- seleciona apenas os profissionais com carga horaria ambulatorial,

--- a/models/marts/core/dimensions/rio/_dimensions_rio_schema.yml
+++ b/models/marts/core/dimensions/rio/_dimensions_rio_schema.yml
@@ -160,6 +160,8 @@ models:
       description: "Ano utilizado para fins de particionamento dos dados."
     - name: data_particao
       description: "Data específica utilizada para particionamento dos dados."
+      tests:
+        - not_null
     - name: data_carga
       description: "Data em que os dados foram carregados no banco de dados."
     - name: data_snapshot
@@ -176,6 +178,8 @@ models:
       # Identificação
       - name: data_particao
         description: "Data usado para o particionamento do conjunto de dados."
+        tests:
+          - not_null
       - name: ano_competencia
         description: "Ano de referência dos dados."
       - name: mes_competencia
@@ -219,6 +223,8 @@ models:
     columns:
       - name: data_particao
         description: "Data usado para o particionamento do conjunto de dados."
+        tests:
+          - not_null
       - name: ano_competencia
         description: "Ano de referência dos dados."
       - name: mes_competencia
@@ -268,6 +274,8 @@ models:
     columns:
       - name: data_particao
         description: "Data usado para o particionamento do conjunto de dados."
+        tests:
+          - not_null
       - name: ano_competencia
         description: "Ano de referência dos dados."
       - name: mes_competencia
@@ -309,6 +317,8 @@ models:
     columns:
       - name: data_particao
         description: "Data usado para o particionamento do conjunto de dados."
+        tests:
+          - not_null
       - name: ano_competencia
         description: "Ano de referência dos dados."
       - name: mes_competencia

--- a/models/marts/core/dimensions/rio/dim_equipamento_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_equipamento_sus_rio_historico.sql
@@ -55,7 +55,10 @@ with
             equipamentos_quantidade_ativos,
             equip.ano_competencia,
             equip.mes_competencia,
-            parse_date('%Y-%m-%d', map_geral.data_particao) as data_particao,
+            -- data_particao determinística (não depende de left join
+            -- contra tabela de referência)
+            -- usa diretamente o snapshot mais atual
+            parse_date('%Y-%m-%d', (select versao from versao_atual)) as data_particao,
 
         from equip
         left join dim_estabelecimentos_sus_rio_historico as estabs using(ano_competencia, mes_competencia, id_cnes)

--- a/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_estabelecimento_sus_rio_historico.sql
@@ -380,7 +380,11 @@ with
             cast(mes as int64) as mes_competencia,
             -- safe_cast(mes_particao as int64) as mes_particao,
             -- safe_cast(ano_particao as int64) as ano_particao,
-            parse_date('%Y-%m-%d', data_particao) as data_particao,
+            
+            -- data_particao determinística (não depende de left join
+            -- contra tabela de referência)
+            -- usa diretamente o snapshot mais atual
+            parse_date('%Y-%m-%d', (select versao from versao_atual)) as data_particao,
             data_carga,
             data_snapshot
 

--- a/models/marts/core/dimensions/rio/dim_habilitacao_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_habilitacao_sus_rio_historico.sql
@@ -62,7 +62,10 @@ with
             habilitacao_mes_fim,
             ano_competencia,
             mes_competencia,
-            parse_date('%Y-%m-%d', map.data_particao) as data_particao,
+            -- data_particao determinística (não depende de left join
+            -- contra tabela de referência)
+            -- usa diretamente o snapshot mais atual
+            parse_date('%Y-%m-%d', (select versao from versao_atual)) as data_particao,
 
         from {{ ref("int_habilitacao_sus_rio_historico__brutos_filtrados") }} as hab
         left join dim_estabelecimentos_sus_rio_historico as estabs using(ano_competencia, mes_competencia, id_cnes)

--- a/models/marts/core/dimensions/rio/dim_leito_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_leito_sus_rio_historico.sql
@@ -67,7 +67,10 @@ with
             web.tipo_especialidade_leito_descr,
             lt.ano_competencia,
             lt.mes_competencia,
-            parse_date('%Y-%m-%d', web.data_particao) as data_particao,
+            -- data_particao determinística (não depende de left join
+            -- contra tabela de referência)
+            -- usa diretamente o snapshot mais atual
+            parse_date('%Y-%m-%d', (select versao from versao_atual)) as data_particao,
 
         from {{ ref("int_leito_sus_rio_historico__brutos_filtrados") }} as lt
         left join dim_estabelecimentos_sus_rio_historico as estabs using(ano_competencia, mes_competencia, id_cnes)

--- a/models/marts/core/dimensions/rio/dim_profissional_sus_rio_historico.sql
+++ b/models/marts/core/dimensions/rio/dim_profissional_sus_rio_historico.sql
@@ -114,7 +114,10 @@ with
 
             p.ano_competencia,
             p.mes_competencia,
-            parse_date('%Y-%m-%d', tipo_vinculo.data_particao) as data_particao
+            -- data_particao determinística (não depende de left join
+            -- contra tabela de referência)
+            -- usa diretamente o snapshot mais atual
+            parse_date('%Y-%m-%d', (select versao from versao_atual)) as data_particao
 
         from profissionais_mrj as p
         left join


### PR DESCRIPTION
Ensure that data_particao is now deterministic by directly using the most current snapshot, eliminating dependencies on left joins. Additionally, add not_null tests for data_particao across relevant models. This was breaking a downstream model (`monitor_vagas_ambulatoriais`).