### PR TITLE
(Vitacare) Atualiza referências ao identificador do paciente

### DIFF
--- a/models/intermediate/dit/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
+++ b/models/intermediate/dit/historico_clinico/paciente/int_historico_clinico__paciente__vitacare.sql
@@ -24,8 +24,8 @@
 with
     paciente as (
         select
-            * except (id, source_updated_at),
-            id as id_paciente,
+            * except (id_paciente_global, source_updated_at),
+            id_paciente_global as id_paciente,
             source_updated_at as updated_at,
             row_number() over (
                 partition by cpf
@@ -482,7 +482,7 @@ with
             cpf,
             'vitacare' as sistema,
             id_cnes,
-            id as id_paciente,
+            id_paciente_global as id_paciente,
             row_number() over (
                 partition by cpf
                 order by source_updated_at

--- a/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente__schema.yml
+++ b/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente__schema.yml
@@ -7,19 +7,22 @@ models:
       contendo apenas registros com CPF e CNES preenchidos.
 
     columns:
-      - name: id
+      - name: id_paciente_global
         description: Identificador único do paciente.
         data_tests:
           - unique:
-              name: int_prontuario_vitacare__paciente__id__unique
+              name: int_prontuario_vitacare__paciente__id_paciente_global__unique
               config:
                 severity: warn
                 warn_if: ">1000"
           - not_null:
-              name: int_prontuario_vitacare__paciente__id__not_null
+              name: int_prontuario_vitacare__paciente__id_paciente_global__not_null
               config:
                 severity: warn
                 warn_if: ">1000"
+
+      - name: id_paciente_local
+        description: Identificador do paciente, único na unidade.
 
       - name: id_cnes
         description: Número CNES da unidade de saúde onde o paciente é atendido.


### PR DESCRIPTION
Atualiza referências ao identificador do paciente VitaCare após a mudança da coluna id para id_paciente_global
Também ajusta os testes de schema e referências downstream no modelo de paciente do histórico clínico