### PR TITLE
[monitora cancer] feat: add risco attribute and update subscore calculations

### DIFF
--- a/macros/monitora_cancer_dias_atraso.sql
+++ b/macros/monitora_cancer_dias_atraso.sql
@@ -1,0 +1,27 @@
+-- dias_atraso =
+-- dias_desde_trigger - threshold
+
+{% macro monitora_cancer_dias_atraso(data_inicio, threshold) %}
+  GREATEST(
+    0,
+    DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), {{ data_inicio }}, DAY) - {{ threshold }}
+  )
+{% endmacro %}
+
+
+/*
+    Dias de atraso de um subscore do monitora_cancer.
+
+    Conta os dias entre `data_inicio` (data do evento gatilho — pode ser
+    data_trigger, data_solicitacao ou data_autorizacao, conforme o subscore)
+    e o dia de hoje no fuso America/Sao_Paulo, descontando o `threshold`
+    (folga em dias antes de começar a contar atraso). O piso 0 garante que,
+    dentro do threshold, dias_atraso = 0 — equivalente a "trigger ativo mas
+    sem atraso ainda".
+
+    Parâmetros:
+      • data_inicio: expressão SQL com a data do gatilho a partir da qual
+        contar o atraso.
+      • threshold: dias de folga subtraídos do date_diff antes do GREATEST.
+        Tipicamente a variável Jinja subscore_N_threshold do modelo.
+*/

--- a/macros/monitora_cancer_subscore.sql
+++ b/macros/monitora_cancer_subscore.sql
@@ -1,0 +1,34 @@
+-- subscore_valor =
+-- fator_risco * 2^(dias_atraso / dias_dobrar_subscore)
+
+{% macro monitora_cancer_subscore(dias_atraso, dias_dobrar_subscore, risco_trigger, teto_atraso) %}
+  COALESCE({{ risco_trigger }}, 1) * POW(
+    2,
+    LEAST({{ dias_atraso }}, {{ teto_atraso }}) / {{ dias_dobrar_subscore }}
+  )
+{% endmacro %}
+
+/*
+    Valor de um subscore de gravidade do monitora_cancer.
+
+    Um subscore é caracterizado pela tupla
+    (trigger, expected, threshold, dias_dobrar_subscore, risco_trigger).
+    O par (trigger, expected, threshold) entra no cálculo apenas de
+    `dias_atraso` (feito fora desta macro). O trigger só gera subscore
+    quando o expected ainda NÃO aconteceu — eventos cujo expected já chegou
+    são filtrados antes de chamar a macro. Esta macro combina dias_atraso,
+    dias_dobrar_subscore e risco_trigger no valor final do subscore:
+
+        subscore_valor = COALESCE(risco_trigger, 1)
+                       * 2 ^ ( LEAST(dias_atraso, teto_atraso) / dias_dobrar_subscore )        
+
+    Componentes:
+      • Fator de risco: COALESCE(risco_trigger, 1). risco_trigger é o risco
+        do evento gatilho (1..4, ou NULL quando não mapeado). Multiplica
+        diretamente o subscore. NULL → fator 1 (sem agravador).
+      • Termo exponencial: a cada `dias_dobrar_subscore` dias de atraso, o
+        termo dobra. O teto `teto_atraso` evita explosão exponencial — com
+        base 2 e dias_dobrar = 5, 90 dias já correspondem a 2^18 = 262144.
+
+    Retorna FLOAT64 (POW e a divisão INT/INT em BigQuery resultam em FLOAT64).
+*/

--- a/macros/monitora_cancer_subscore_normalizado.sql
+++ b/macros/monitora_cancer_subscore_normalizado.sql
@@ -1,0 +1,42 @@
+-- subscore_normalizado =
+-- subscore / ( max_risco_trigger * 2^(teto_atraso / dias_dobrar_subscore) )
+
+{% macro monitora_cancer_subscore_normalizado(
+    subscore_valor,
+    dias_dobrar_subscore,
+    teto_atraso,
+    max_risco_trigger=4
+) %}
+    {{ subscore_valor }} / (
+      {{ max_risco_trigger }} * POW(
+        2,
+        {{ teto_atraso }} / {{ dias_dobrar_subscore }}
+        )
+    )
+{% endmacro %}
+
+
+/*
+    Normaliza um subscore de gravidade do monitora_cancer para [0, 1].
+
+    Divide o valor bruto do subscore (produzido por
+    [[monitora_cancer_subscore]]) pelo MAIOR valor que ele poderia assumir,
+    dado o teto de atraso e a constante de risco máximo do projeto:
+
+    O denominador é o valor que o próprio subscore atingiria com
+    risco_trigger no máximo da escala (max_risco_trigger) e dias_atraso
+    saturado no teto (teto_atraso). Como o subscore bruto é monotonicamente
+    crescente em dias_atraso e em risco_trigger, e ambos têm cotas
+    superiores, o resultado fica no intervalo (0, 1].
+
+    Parâmetros:
+      • subscore_valor: expressão SQL com o subscore bruto a normalizar
+        (saída de [[monitora_cancer_subscore]]).
+      • dias_dobrar_subscore: mesmo parâmetro usado para produzir o
+        subscore bruto — controla quão rápido o termo exponencial cresce.
+      • teto_atraso: cap de dias_atraso usado no subscore bruto (LEAST).
+        Precisa ser o MESMO valor passado para [[monitora_cancer_subscore]],
+        senão a normalização vira inconsistente com o numerador.
+      • max_risco_trigger: maior valor possível de risco_trigger no
+        domínio do projeto. Default 4 (escala 1..4 em monitora_cancer).
+*/

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__eventos_episodios.sql
@@ -85,6 +85,7 @@ with
             fcts.atraso_solicitacao_autorizacao,
             fcts.atraso_autorizacao_execucao,
             fcts.atraso_regulacao,
+            fcts.risco,
             (
                 select max(d)
                 from unnest ([
@@ -260,6 +261,7 @@ select
     ev.atraso_solicitacao_autorizacao,
     ev.atraso_autorizacao_execucao,
     ev.atraso_regulacao,
+    ev.risco,
 
     ev.dias_proximo_evento,
     ev.run_id,

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__gravidade.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__gravidade.sql
@@ -1,15 +1,70 @@
 -- noqa: disable=LT08
 
+-- Parâmetros de cada subscore em dias.
+-- Cada subscore usa este valor em DOIS pontos:
+--   • threshold subtraído no cálculo de dias_atraso (folga antes de começar a contar atraso).
+--   • dias_dobrar_subscore na fórmula do subscore (a cada N dias de atraso,
+--     o termo exponencial dobra).
+-- Convenção atual: dias_dobrar_subscore = threshold por subscore.
+{% set subscore_1_threshold = 10 %}  {# SISCAN mama Cat 0/4/5 → SISREG ultra/biópsia #}
+{% set subscore_2_threshold = 5 %}   {# SISCAN mama Cat 6 → qualquer SER #}
+{% set subscore_3_threshold = 5 %}   {# SISCAN biópsia neoplásica → qualquer SER #}
+{% set subscore_4_threshold = 20 %}  {# SISREG biópsia → progresso intra-evento (2 legs) #}
+{% set subscore_5_threshold = 10 %}  {# SER status "PENDENTE" → atualização #}
+{% set subscore_6_threshold = 60 %}  {# SER status "EM FILA" → atualização #}
+{% set subscore_7_threshold = 10 %}  {# SER falha → nova solicitação SER #}
+
+-- Teto (em dias) aplicado a dias_atraso dentro do termo exponencial do subscore,
+-- evitando explosão. Usado em DOIS pontos:
+--   • LEAST(dias_atraso, teto_atraso) dentro da macro monitora_cancer_subscore.
+--   • Denominador da normalização (subscore_valor máximo possível por trigger),
+--     na macro monitora_cancer_subscore_normalizado.
+{% set teto_atraso = 90 %}
+
+-- Maior valor possível de risco_trigger no domínio de monitora_cancer.
+{% set max_risco = 4 %}
+
 -- Score de gravidade da paciente no monitoramento de câncer de mama.
 --
--- Conceito: para cada par (trigger, expected, threshold) — chamado "subscore" —
--- conta-se quantos dias o desfecho esperado atrasou para acontecer após o
--- evento gatilho, descontando a folga do threshold:
+-- Conceito: para cada subscore — caracterizado pela tupla
+-- (trigger, expected, threshold, dias_dobrar_subscore, risco_trigger) —
+-- o TRIGGER só gera subscore enquanto o EXPECTED ainda NÃO chegou. Quando o
+-- desfecho esperado acontece, o trigger é desativado e não contribui mais
+-- ao score (não há entrada no breakdown para esse trigger).
 --
---   dias_atraso = max(0, date_diff(expected_date_ou_hoje, trigger_date) - threshold)
+-- Para triggers ainda ativos, mede-se quantos dias o desfecho está atrasado
+-- (contagem desde o trigger até hoje, descontada a folga do threshold):
 --
--- O gravidade_score do paciente é a SOMA das parcelas de todos os triggers
--- de todos os subscores, multiplicada por 2 se a paciente for gestante.
+--   dias_atraso = max(0, date_diff(hoje, trigger_date) - threshold)
+--
+-- O valor BRUTO de cada subscore (parcela que aquele trigger contribui ao
+-- score, antes da normalização) é:
+--
+--   subscore_valor = coalesce(risco_trigger, 1)
+--                  * 2 ^ ( min(dias_atraso, teto_atraso) / dias_dobrar_subscore )
+--
+-- Implementado na macro monitora_cancer_subscore. Componentes:
+--   • Fator de risco: coalesce(risco_trigger, 1). risco_trigger é o risco
+--     do evento gatilho (1..4, ou NULL quando não mapeado). Multiplica
+--     diretamente o subscore; NULL → fator 1 (sem agravador).
+--   • dias_dobrar_subscore controla a velocidade de crescimento: a cada
+--     `dias_dobrar_subscore` dias de atraso, o termo exponencial dobra. O
+--     teto `teto_atraso` evita explosão.
+-- Observação: dentro do threshold, dias_atraso=0 → termo exponencial=2^0=1,
+-- ou seja, todo trigger ativo contribui com no mínimo 1 × fator de risco.
+--
+-- Antes da agregação, cada subscore bruto é NORMALIZADO para (0, 1] dividindo
+-- pelo seu próprio máximo teórico (max_risco × termo exponencial saturado em
+-- teto_atraso) — implementado na macro monitora_cancer_subscore_normalizado:
+--
+--   subscore_normalizado = subscore_valor
+--                        / ( max_risco * 2 ^ ( teto_atraso / dias_dobrar_subscore ) )
+--
+-- max_risco é o maior risco_trigger possível no domínio (hoje = 4 em todas
+-- as fontes que produzem triggers).
+--
+-- O gravidade_score do paciente é a SOMA dos subscores NORMALIZADOS de todos
+-- os triggers ATIVOS, multiplicada por 2 se a paciente for gestante.
 --
 -- Escopo temporal: apenas eventos do RUN ATUAL (último episódio) entram no
 -- cálculo. Eventos de runs antigos (separados por > episodio_gap_dias)
@@ -17,43 +72,37 @@
 --
 -- Convenções:
 --   trigger_date  = data_referencia_evento (= MAX das 4 datas do evento)
---   expected_date = COALESCE(data_execucao, data_autorizacao)
---                   (eventos só com data_solicitacao ainda na fila NÃO contam)
+--   expected_date = COALESCE(data_execucao, data_autorizacao) — usada apenas
+--                   no filtro de desativação (NOT EXISTS / WHERE x IS NULL);
+--                   nunca entra no cálculo de dias_atraso (que é sempre
+--                   contado de trigger_date até hoje).
 --
--- Subscores atuais:
---   1) SISCAN mamografia Cat 0/4/5  →  SISREG ultra/biópsia,         threshold 10 dias
---   2) SISCAN mamografia Cat 6      →  qualquer evento SER,          threshold  5 dias
---   3) SISCAN biópsia neoplásica    →  qualquer evento SER,          threshold  5 dias
---   4) SISREG biópsia               →  progresso intra-evento,       threshold 20 dias
+-- Subscores atuais (valores parametrizados no topo do arquivo;
+-- dias_dobrar_subscore = threshold em todos):
+--   1) SISCAN mamografia Cat 0/4/5  →  SISREG ultra/biópsia,         threshold subscore_1_threshold
+--   2) SISCAN mamografia Cat 6      →  qualquer evento SER,          threshold subscore_2_threshold
+--   3) SISCAN biópsia neoplásica    →  qualquer evento SER,          threshold subscore_3_threshold
+--   4) SISREG biópsia               →  progresso intra-evento,       threshold subscore_4_threshold
 --      (decomposto em dois legs: solicitacao→autorizacao e autorizacao→execucao)
---   5) SER status "PENDENTE"        →  atualização do status,        threshold 10 dias
---   6) SER status "EM FILA"         →  atualização do status,        threshold 60 dias
---   7) SER status falha             →  nova solicitação SER,         threshold 10 dias
+--   5) SER status "PENDENTE"        →  atualização do status,        threshold subscore_5_threshold
+--   6) SER status "EM FILA"         →  atualização do status,        threshold subscore_6_threshold
+--   7) SER status falha             →  nova solicitação SER,         threshold subscore_7_threshold
 --      (CHEGADA NAO CONFIRMADA, CANCELADA)
 --
--- Para adicionar um subscore: criar mais um par de CTEs `subscore_N_triggers`
--- + `subscore_N` no padrão abaixo e incluir no UNION ALL de `todos_atrasos`.
--- Subscores intra-evento (mesmo evento de origem para trigger e expected)
--- são single-row: dispensam JOIN porque trigger e expected vêm da mesma linha.
--- Para subscores em que o expected é "status saiu do valor inicial" e o
--- snapshot só guarda o status corrente, a presença da linha com aquele
--- status é evidência de que a atualização ainda não ocorreu — então
--- data_expected = NULL e o atraso conta de data_solicitacao até hoje.
+-- Mecanismo de desativação por padrão:
+--   • Cross-evento (1, 2, 3, 7): WHERE NOT EXISTS contra a CTE de expected
+--     (deduplicada). Quando aparece qualquer expected ≥ trigger_date — ou
+--     > trigger_date no caso de 7 — o trigger some do output.
+--   • Intra-evento legs (4): filtro direto `data_proxima IS NULL` (a coluna
+--     do desfecho do leg) na WHERE.
+--   • Intra-evento "stuck" (5, 6): filtro `evento_status IN ('PENDENTE'/...)`
+--     já age como desativação — quando o status muda, a linha some.
 --
--- Overlaps conhecidos entre subscores (intencionais — são dimensões
--- distintas do mesmo atraso, não double-counting acidental):
---   • Subscore 1 (expected = SISREG biópsia) ↔ Subscore 4 (trigger =
---     SISREG biópsia): uma biópsia atrasada contribui em (1) pelo gap
---     SISCAN→SISREG e em (4) pelos gaps internos do pipeline SISREG.
---     Períodos temporais distintos, contribuições somam.
---   • Subscores 5 e 6 são mutuamente exclusivos por linha (filtros de
---     evento_status disjuntos), assim como 7 vs. 5/6.
---   • Subscore 7 (expected = nova SER) pode usar como expected uma SER
---     que ela própria seja trigger de 5/6. Ex.: SER cancelada → nova SER
---     PENDENTE há 30 dias dispara 7 (cancelada) E 5 (pendente).
---   • Subscores 2/3 (expected requer data_execucao ou data_autorizacao
---     preenchidas) NÃO sobrepõem a 5/6 (que filtram linhas em PENDENTE/
---     EM FILA, com essas datas necessariamente nulas).
+-- Para adicionar um subscore: criar `subscore_N_triggers` (com dedup
+-- group by cpf+data_trigger e max(risco) se cross-evento) + `subscore_N`
+-- (anti-join NOT EXISTS para cross-evento, ou WHERE direto para intra) e
+-- incluir no UNION ALL de `todos_atrasos`. Subscores intra-evento dispensam
+-- JOIN/anti-join porque trigger e desfecho vêm da mesma linha.
 
 with
     -- Eventos do RUN ATUAL apenas, com a data_expected pré-calculada.
@@ -71,16 +120,20 @@ with
             data_execucao,
             data_referencia_evento,
             coalesce(data_execucao, data_autorizacao) as data_expected,
+            risco,
             gestante
         from {{ ref("int_monitora_cancer__eventos_episodios") }}
         qualify run_id = max(run_id) over (partition by cpf_particao)
     ),
 
     -- ── Subscore 1: SISCAN mama Cat 0/4/5 → SISREG ultra/biópsia, threshold 10 ──
+    -- Dedup por (cpf, data_trigger) com max(risco): múltiplos eventos SISCAN
+    -- no mesmo dia colapsam em um único trigger, mantendo o pior risco.
     subscore_1_triggers as (
         select
             cpf_particao,
-            data_referencia_evento as data_trigger
+            data_referencia_evento as data_trigger,
+            max(risco) as risco_trigger
         from eventos_run_atual
         where fonte = 'SISCAN'
             and procedimento in (
@@ -95,6 +148,7 @@ with
                 or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 4')
                 or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 5')
             )
+        group by cpf_particao, data_referencia_evento
     ),
 
     subscore_1_expected as (
@@ -113,25 +167,22 @@ with
             and data_expected is not null
     ),
 
+    -- Trigger só gera subscore quando o expected ainda NÃO chegou (NOT EXISTS).
+    -- dias_atraso é contado de data_trigger até hoje (descontado o threshold).
     subscore_1 as (
         select
             t.cpf_particao,
             'SISCAN_MAMA_CAT_0_4_5__SISREG_ULTRA_OU_BIOPSIA' as subscore,
             t.data_trigger,
-            min(e.data_expected) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
-                    t.data_trigger,
-                    day
-                ) - 10
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('t.data_trigger', subscore_1_threshold) }} as dias_atraso,
+            {{ subscore_1_threshold }} as dias_dobrar_subscore,
+            t.risco_trigger
         from subscore_1_triggers as t
-            left join subscore_1_expected as e
-            on t.cpf_particao = e.cpf_particao
+        where not exists (
+            select 1 from subscore_1_expected as e
+            where t.cpf_particao = e.cpf_particao
                 and e.data_expected >= t.data_trigger
-        group by t.cpf_particao, t.data_trigger
+        )
     ),
 
     -- Expecteds compartilhados pelos subscores 2 e 3: qualquer evento SER.
@@ -148,7 +199,8 @@ with
     subscore_2_triggers as (
         select
             cpf_particao,
-            data_referencia_evento as data_trigger
+            data_referencia_evento as data_trigger,
+            max(risco) as risco_trigger
         from eventos_run_atual
         where fonte = 'SISCAN'
             and procedimento in (
@@ -159,6 +211,7 @@ with
                 starts_with(coalesce(mama_esquerda_resultado, ''), 'Categoria 6')
                 or starts_with(coalesce(mama_direita_resultado, ''), 'Categoria 6')
             )
+        group by cpf_particao, data_referencia_evento
     ),
 
     subscore_2 as (
@@ -166,20 +219,15 @@ with
             t.cpf_particao,
             'SISCAN_MAMA_CAT_6__SER' as subscore,
             t.data_trigger,
-            min(e.data_expected) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
-                    t.data_trigger,
-                    day
-                ) - 5
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('t.data_trigger', subscore_2_threshold) }} as dias_atraso,
+            {{ subscore_2_threshold }} as dias_dobrar_subscore,
+            t.risco_trigger
         from subscore_2_triggers as t
-            left join expected_ser as e
-            on t.cpf_particao = e.cpf_particao
+        where not exists (
+            select 1 from expected_ser as e
+            where t.cpf_particao = e.cpf_particao
                 and e.data_expected >= t.data_trigger
-        group by t.cpf_particao, t.data_trigger
+        )
     ),
 
     -- ── Subscore 3: SISCAN biópsia neoplásica → qualquer SER, threshold 5 ──
@@ -188,7 +236,8 @@ with
     subscore_3_triggers as (
         select
             cpf_particao,
-            data_referencia_evento as data_trigger
+            data_referencia_evento as data_trigger,
+            max(risco) as risco_trigger
         from eventos_run_atual
         where fonte = 'SISCAN'
             and procedimento not in (
@@ -196,6 +245,7 @@ with
                 'RESULTADO MAMOGRAFIA DIAGNOSTICA'
             )
             and criterio_diagnostico = true
+        group by cpf_particao, data_referencia_evento
     ),
 
     subscore_3 as (
@@ -203,20 +253,15 @@ with
             t.cpf_particao,
             'SISCAN_BIOPSIA_NEOPLASICA__SER' as subscore,
             t.data_trigger,
-            min(e.data_expected) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
-                    t.data_trigger,
-                    day
-                ) - 5
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('t.data_trigger', subscore_3_threshold) }} as dias_atraso,
+            {{ subscore_3_threshold }} as dias_dobrar_subscore,
+            t.risco_trigger
         from subscore_3_triggers as t
-            left join expected_ser as e
-            on t.cpf_particao = e.cpf_particao
+        where not exists (
+            select 1 from expected_ser as e
+            where t.cpf_particao = e.cpf_particao
                 and e.data_expected >= t.data_trigger
-        group by t.cpf_particao, t.data_trigger
+        )
     ),
 
     -- ── Subscore 4: SISREG biópsia → progresso entre datas intra-evento, threshold 20 ──
@@ -232,65 +277,52 @@ with
     -- disso, o ônus do atraso está totalmente em leg 1.
     subscore_4 as (
         -- leg 1: solicitacao → autorizacao
+        -- Trigger só ativo quando data_autorizacao ainda NÃO chegou.
         select
             cpf_particao,
             'SISREG_BIOPSIA__SOLICITACAO_AUTORIZACAO' as subscore,
             data_solicitacao as data_trigger,
-            data_autorizacao as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(data_autorizacao, current_date('America/Sao_Paulo')),
-                    data_solicitacao,
-                    day
-                ) - 20
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('data_solicitacao', subscore_4_threshold) }} as dias_atraso,
+            {{ subscore_4_threshold }} as dias_dobrar_subscore,
+            risco as risco_trigger
         from eventos_run_atual
         where fonte = 'SISREG'
             and contains_substr(procedimento, 'BIOPSIA')
             and data_solicitacao is not null
+            and data_autorizacao is null
 
         union all
 
         -- leg 2: autorizacao → execucao
+        -- Trigger só ativo quando data_execucao ainda NÃO chegou.
         select
             cpf_particao,
             'SISREG_BIOPSIA__AUTORIZACAO_EXECUCAO' as subscore,
             data_autorizacao as data_trigger,
-            data_execucao as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(data_execucao, current_date('America/Sao_Paulo')),
-                    data_autorizacao,
-                    day
-                ) - 20
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('data_autorizacao', subscore_4_threshold) }} as dias_atraso,
+            {{ subscore_4_threshold }} as dias_dobrar_subscore,
+            risco as risco_trigger
         from eventos_run_atual
         where fonte = 'SISREG'
             and contains_substr(procedimento, 'BIOPSIA')
             and data_autorizacao is not null
+            and data_execucao is null
     ),
 
     -- ── Subscore 5: SER status "PENDENTE" → atualização do status, threshold 10 ──
     -- Intra-evento "stuck": a linha com evento_status = 'PENDENTE' no snapshot
-    -- corrente é prova de que a coluna de status ainda não foi atualizada —
-    -- logo data_expected é sempre NULL e o atraso conta de data_solicitacao
-    -- até hoje (cai no COALESCE de current_date).
+    -- corrente é prova de que a atualização do status ainda não ocorreu — quando
+    -- o status muda, a linha sai do filtro e o trigger é automaticamente
+    -- desativado (sem precisar de anti-join). dias_atraso conta de
+    -- data_solicitacao até hoje.
     subscore_5 as (
         select
             cpf_particao,
             'SER_PENDENTE__STATUS_UPDATE' as subscore,
             data_solicitacao as data_trigger,
-            cast(null as date) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    current_date('America/Sao_Paulo'),
-                    data_solicitacao,
-                    day
-                ) - 10
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('data_solicitacao', subscore_5_threshold) }} as dias_atraso,
+            {{ subscore_5_threshold }} as dias_dobrar_subscore,
+            risco as risco_trigger
         from eventos_run_atual
         where fonte = 'SER'
             and evento_status = 'PENDENTE'
@@ -304,15 +336,9 @@ with
             cpf_particao,
             'SER_EM_FILA__STATUS_UPDATE' as subscore,
             data_solicitacao as data_trigger,
-            cast(null as date) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    current_date('America/Sao_Paulo'),
-                    data_solicitacao,
-                    day
-                ) - 60
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('data_solicitacao', subscore_6_threshold) }} as dias_atraso,
+            {{ subscore_6_threshold }} as dias_dobrar_subscore,
+            risco as risco_trigger
         from eventos_run_atual
         where fonte = 'SER'
             and evento_status = 'EM FILA'
@@ -331,10 +357,12 @@ with
     subscore_7_triggers as (
         select
             cpf_particao,
-            data_referencia_evento as data_trigger
+            data_referencia_evento as data_trigger,
+            max(risco) as risco_trigger
         from eventos_run_atual
         where fonte = 'SER'
             and evento_status in ('CHEGADA NAO CONFIRMADA', 'CANCELADA')
+        group by cpf_particao, data_referencia_evento
     ),
 
     expected_ser_nova_solicitacao as (
@@ -351,20 +379,15 @@ with
             t.cpf_particao,
             'SER_FALHA__NOVA_SER' as subscore,
             t.data_trigger,
-            min(e.data_expected) as data_expected,
-            greatest(
-                0,
-                date_diff(
-                    coalesce(min(e.data_expected), current_date('America/Sao_Paulo')),
-                    t.data_trigger,
-                    day
-                ) - 10
-            ) as dias_atraso
+            {{ monitora_cancer_dias_atraso('t.data_trigger', subscore_7_threshold) }} as dias_atraso,
+            {{ subscore_7_threshold }} as dias_dobrar_subscore,
+            t.risco_trigger
         from subscore_7_triggers as t
-            left join expected_ser_nova_solicitacao as e
-            on t.cpf_particao = e.cpf_particao
+        where not exists (
+            select 1 from expected_ser_nova_solicitacao as e
+            where t.cpf_particao = e.cpf_particao
                 and e.data_expected > t.data_trigger
-        group by t.cpf_particao, t.data_trigger
+        )
     ),
 
     todos_atrasos as (
@@ -383,20 +406,57 @@ with
         select * from subscore_7
     ),
 
+    -- Aplica a fórmula
+    --   subscore_valor = coalesce(risco_trigger, 1)
+    --                  * 2 ^ (min(dias_atraso, teto_atraso) / dias_dobrar_subscore)
+    -- uma única vez por linha. Isolar em CTE evita recomputar a expressão
+    -- dentro da normalização, do sum() e do array_agg(struct(...)).
+    subscores_brutos as (
+        select
+            cpf_particao,
+            subscore,
+            data_trigger,
+            dias_atraso,
+            dias_dobrar_subscore,
+            risco_trigger,
+            {{ monitora_cancer_subscore('dias_atraso', 'dias_dobrar_subscore', 'risco_trigger', teto_atraso) }} as subscore_valor
+        from todos_atrasos
+    ),
+
+    -- Normalização do subscore para (0, 1] (divide pelo máximo teórico que
+    -- aquele subscore poderia atingir, dado risco_trigger no topo da escala
+    -- e dias_atraso saturado em teto_atraso). É o valor que entra na soma
+    -- final do gravidade_score.
+    subscores as (
+        select
+            cpf_particao,
+            subscore,
+            data_trigger,
+            dias_atraso,
+            dias_dobrar_subscore,
+            risco_trigger,
+            subscore_valor,
+            {{ monitora_cancer_subscore_normalizado('subscore_valor', 'dias_dobrar_subscore', teto_atraso, max_risco) }} as subscore_valor_normalizado
+        from subscores_brutos
+    ),
+
     agregado as (
         select
             cpf_particao,
-            sum(dias_atraso) as gravidade_score_base,
+            sum(subscore_valor_normalizado) as gravidade_score_base,
             array_agg(
                 struct(
                     subscore,
                     data_trigger,
-                    data_expected,
-                    dias_atraso
+                    dias_atraso,
+                    dias_dobrar_subscore,
+                    risco_trigger,
+                    subscore_valor,
+                    subscore_valor_normalizado
                 )
                 order by data_trigger desc, subscore
             ) as gravidade_breakdown
-        from todos_atrasos
+        from subscores
         group by cpf_particao
     ),
 

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__ser_ambulatorial.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__ser_ambulatorial.sql
@@ -104,6 +104,14 @@ select
         when date_diff(data_execucao, data_solicitacao, day) >= limite_dias_regulacao + 10 then 2
         when date_diff(data_execucao, data_solicitacao, day) >= limite_dias_regulacao then 1
         else 0
-    end as atraso_regulacao
+    end as atraso_regulacao,
+
+-- risco (float64): prioridade do SER convertida para numérico.
+-- Casos inválidos (ex.: string 'nan' ou texto não numérico) viram NULL.
+-- Subquery + unnest garante uma única avaliação do safe_cast por linha.
+    (
+        select if(is_nan(p), null, p)
+        from unnest([safe_cast(prioridade as float64)]) as p
+    ) as risco
 
 from enriquecido

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__siscan.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__siscan.sql
@@ -62,7 +62,41 @@ select
 -- apenas para SER/SISREG
     cast(NULL as int64) as atraso_solicitacao_autorizacao,
     cast(NULL as int64) as atraso_autorizacao_execucao,
-    cast(NULL as int64) as atraso_regulacao
+    cast(NULL as int64) as atraso_regulacao,
+
+-- risco (float64): derivado de três fontes do laudo SISCAN, combinadas pelo MAIOR risco.
+-- 1) Categoria BI-RADS de cada mama:
+--    Cat 1/2 = 1.0 (sem achados / benignos); Cat 0/3 = 2.0 (avaliação adicional / provavelmente benignos);
+--    Cat 4 = 3.0 (achados suspeitos); Cat 5/6 = 4.0 (altamente suspeitos / com diagnóstico).
+-- 2) Tipo de rastreamento (mamografia_rastreamento_tipo):
+--    "População de risco elevado (história familiar)" = 4.0;
+--    "Paciente já tratado de câncer de mama" = 3.0;
+--    "População alvo" = 1.0; demais = NULL.
+-- NULL se nenhuma das fontes casar com o mapeamento.
+    (
+        select max(r) from unnest([
+            case safe_cast(regexp_extract(mama_esquerda_classif_radiologica, r'Categoria (\d+)') as int64)
+                when 1 then 1.0 when 2 then 1.0
+                when 0 then 2.0 when 3 then 2.0
+                when 4 then 3.0
+                when 5 then 4.0 when 6 then 4.0
+                else null
+            end,
+            case safe_cast(regexp_extract(mama_direita_classif_radiologica, r'Categoria (\d+)') as int64)
+                when 1 then 1.0 when 2 then 1.0
+                when 0 then 2.0 when 3 then 2.0
+                when 4 then 3.0
+                when 5 then 4.0 when 6 then 4.0
+                else null
+            end,
+            case mamografia_rastreamento_tipo
+                when 'População de risco elevado (história familiar)' then 4.0
+                when 'Paciente já tratado de câncer de mama' then 3.0
+                when 'População alvo' then 1.0
+                else null
+            end
+        ]) as r
+    ) as risco
 
 from {{ ref("raw_siscan_web__laudos") }}
 where 1 = 1

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__siscan_histo_mama.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__siscan_histo_mama.sql
@@ -50,7 +50,16 @@ select
 -- apenas para SER/SISREG
     cast(NULL as int64) as atraso_solicitacao_autorizacao,
     cast(NULL as int64) as atraso_autorizacao_execucao,
-    cast(NULL as int64) as atraso_regulacao
+    cast(NULL as int64) as atraso_regulacao,
+
+-- risco (float64): derivado do grau histológico (agressividade do tumor).
+-- I = 2.0, II = 3.0, III = 4.0; demais valores e ausência = NULL.
+    case upper(trim(grau_histologico))
+        when 'I' then 2.0
+        when 'II' then 3.0
+        when 'III' then 4.0
+        else null
+    end as risco
 
 from {{ ref("raw_siscan_web__laudos_histo_mama") }}
 where 1 = 1

--- a/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__sisreg.sql
+++ b/models/intermediate/subgeral/monitora_cancer/int_monitora_cancer__sisreg.sql
@@ -41,6 +41,7 @@ with
             base.id_cnes_unidade_executante,
             base.cid_solicitacao,
             base.solicitacao_status,
+            base.solicitacao_risco,
             proc.procedimento,
             safe_cast(base.data_solicitacao as date) as data_solicitacao,
             safe_cast(base.data_autorizacao as date) as data_autorizacao,
@@ -111,6 +112,16 @@ select
         when date_diff(data_execucao, data_solicitacao, day) >= limite_dias_regulacao + 10 then 2
         when date_diff(data_execucao, data_solicitacao, day) >= limite_dias_regulacao then 1
         else 0
-    end as atraso_regulacao
+    end as atraso_regulacao,
+
+-- risco (float64): mapeia o risco da solicitação do SISREG em escala numérica.
+-- AZUL = 1.0 (menor), VERDE = 2.0, AMARELO = 3.0, VERMELHO = 4.0 (maior); demais = NULL.
+    case upper(trim(solicitacao_risco))
+        when 'AZUL' then 1.0
+        when 'VERDE' then 2.0
+        when 'AMARELO' then 3.0
+        when 'VERMELHO' then 4.0
+        else null
+    end as risco
 
 from enriquecido

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -161,6 +161,25 @@ models:
               quote: false
               name: mart_monitora_cancer__fatos__atraso_regulacao__accepted_values
 
+      # ── risco ────────────────────────────────────────────────────────────────
+      - name: risco
+        description: >
+          Score numérico (int) de risco do evento, normalizado entre sistemas
+          de origem na camada intermediária (int_monitora_cancer__*). Quanto maior
+          o valor, maior o risco. Mapeamento por fonte:
+          (SISREG) AZUL=1, VERDE=2, AMARELO=3, VERMELHO=4;
+          (SER) prioridade convertida diretamente para float64 — valores não
+          numéricos (ex.: "nan") viram NULL;
+          (SISCAN Mamografia) BI-RADS 1/2=1, 0/3=2, 4=3, 5/6=4; quando
+          há resultado nas duas mamas, retém-se o maior risco;
+          (SISCAN Histo Mama) grau histológico I=2, II=3, III=4.
+          NULL quando o evento não tem informação de risco mapeada.
+        data_tests:
+          - accepted_values:
+              values: [1.0, 2.0, 3.0, 4.0]
+              quote: false
+              name: mart_monitora_cancer__fatos__risco__accepted_values
+
       # ── unidade solicitante ────────────────────────────────────────────────────
       - name: id_cnes_unidade_origem
         description: Código CNES da unidade que originou / solicitou o evento.
@@ -319,6 +338,7 @@ models:
           tipo de evento, status, procedimento, CID, unidade solicitante,
           unidade executante, datas (solicitação, autorização, execução,
           resultado) em formato date e string, resultados dos exames das mamas,
+          severidades de atraso, score de risco (float64) normalizado por sistema,
           o intervalo em dias até o próximo evento (dias_proximo_evento) e o
           identificador do episódio (jornada_id) ao qual o evento pertence —
           episódios são sequências consecutivas de eventos cujos gaps entre
@@ -409,6 +429,20 @@ models:
           Severidade (0-3) do atraso entre data_solicitacao e data_execucao
           (tempo total de regulação). NULL para SISCAN e quando alguma das
           datas está ausente.
+
+      - name: eventos.risco
+        description: >
+          Score numérico (float64) de risco do evento, normalizado entre sistemas
+          de origem na camada intermediária. Quanto maior o valor, maior o risco.
+          Mapeamento por fonte:
+          (SISREG) AZUL=1.0, VERDE=2.0, AMARELO=3.0, VERMELHO=4.0;
+          (SER) prioridade convertida diretamente para float64 — valores não
+          numéricos (ex.: "nan") viram NULL;
+          (SISCAN Mamografia) BI-RADS 1/2=1.0, 0/3=2.0, 4=3.0, 5/6=4.0; quando
+          há resultado nas duas mamas, retém-se o maior risco;
+          (SISCAN Histo Mama) grau histológico I=1.0, II=2.0, III=3.0.
+          NULL quando o evento não tem informação de risco mapeada. Validação
+          do domínio é coberta pelo accepted_values em mart_monitora_cancer__fatos.risco.
 
       - name: eventos.dias_proximo_evento
         description: >

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -269,15 +269,18 @@ models:
 
       - name: gravidade_score
         description: >
-          Soma de "dias de atraso" da paciente, calculada em
-          mart_monitora_cancer__gravidade. Para cada subscore (par
-          trigger/expected/threshold), conta-se quantos dias o desfecho
-          esperado atrasou após o evento gatilho, descontando a folga do
-          threshold. O total é multiplicado por 2 quando a paciente é
-          gestante. Pacientes sem nenhum trigger no run atual recebem 0.
-          Valores maiores indicam pacientes com mais atrasos acumulados na
-          linha de cuidado e, portanto, potencialmente mais críticas de
-          acompanhar.
+          Score de gravidade (FLOAT64) da paciente, calculado em
+          mart_monitora_cancer__gravidade. Cada trigger só gera subscore
+          enquanto o desfecho esperado ainda NÃO chegou — quando o expected
+          acontece, o trigger é desativado e some do score. Para triggers
+          ativos: dias_atraso = max(0, date_diff(hoje, trigger) - threshold)
+          e subscore_valor = coalesce(risco_trigger, 1)
+                           * 2 ^ (min(dias_atraso, 90) / dias_dobrar_subscore).
+          O score é a soma dos valores dos subscores ativos da paciente,
+          multiplicada por 2 quando a paciente é gestante. Pacientes sem
+          nenhum trigger ativo no run atual recebem 0. Valores maiores
+          indicam pacientes com mais atrasos acumulados na linha de cuidado
+          e, portanto, potencialmente mais críticas de acompanhar.
 
       - name: tempo_total
         description: >
@@ -466,14 +469,28 @@ models:
 
   - name: mart_monitora_cancer__gravidade
     description: >
-      Score de gravidade da paciente no monitoramento de câncer de mama,
-      calculado como a soma dos "dias de atraso" entre cada evento gatilho
-      (trigger) e o respectivo desfecho esperado (expected outcome) — descontada
-      a folga do threshold de cada subscore — multiplicada por 2 se a paciente
-      for gestante. Considera apenas eventos do RUN ATUAL (último episódio de
-      cuidado) de cada paciente.
+      Score de gravidade da paciente no monitoramento de câncer de mama.
+      Cada trigger só gera subscore enquanto o desfecho esperado (expected)
+      ainda NÃO chegou — quando o expected acontece, o trigger é desativado
+      e não aparece no breakdown. Para triggers ativos:
+      dias_atraso = max(0, date_diff(hoje, trigger) - threshold) e
+      subscore_valor = coalesce(risco_trigger, 1)
+                     * 2 ^ (min(dias_atraso, teto_atraso) / dias_dobrar_subscore),
+      via macro monitora_cancer_subscore. O fator de risco multiplica
+      diretamente o subscore conforme o risco do evento gatilho (escala
+      1..4); triggers sem risco mapeado recebem fator 1. Antes da soma, cada
+      subscore é normalizado para (0, 1] via macro
+      monitora_cancer_subscore_normalizado:
+      subscore_valor_normalizado = subscore_valor
+                                 / ( max_risco * 2 ^ (teto_atraso / dias_dobrar_subscore) ).
+      O score final é a SOMA dos subscores NORMALIZADOS de todos os triggers
+      ativos da paciente, multiplicada por 2 se ela for gestante. Considera
+      apenas eventos do RUN ATUAL (último episódio de cuidado) de cada
+      paciente.
 
-      Subscores atualmente implementados:
+      Subscores atualmente implementados (thresholds parametrizados no topo
+      de int_monitora_cancer__gravidade.sql; dias_dobrar_subscore = threshold
+      em todos):
         1. SISCAN mamografia Cat 0/4/5 → SISREG ultrassonografia ou biópsia,
            threshold 10 dias.
         2. SISCAN mamografia Cat 6 → qualquer evento SER, threshold 5 dias.
@@ -488,12 +505,16 @@ models:
         7. SER status de falha ("CHEGADA NAO CONFIRMADA", "CANCELADA")
            → nova solicitação SER, threshold 10 dias.
 
-      Convenções de data: trigger_date = data_referencia_evento (MAX das 4
-      datas do evento); expected_date = COALESCE(data_execucao, data_autorizacao).
-      Eventos esperados ainda só com data_solicitacao não zeram o atraso.
+      Mecanismo de desativação:
+        • Cross-evento (1, 2, 3, 7): NOT EXISTS contra a CTE de expected.
+          Quando aparece qualquer expected ≥ trigger (> em 7), o trigger some.
+        • Intra-evento legs (4): WHERE direto exigindo a data do desfecho
+          do leg = NULL.
+        • Intra-evento "stuck" (5, 6): WHERE no evento_status — quando o
+          status muda, a linha some naturalmente.
 
       Granularidade: 1 linha por paciente (cpf_particao). Apenas pacientes
-      com pelo menos um trigger no run atual estão presentes.
+      com pelo menos um trigger ativo no run atual estão presentes.
     meta:
       owner: "SMS/SUBGERAL/CR/NTI"
 
@@ -512,18 +533,25 @@ models:
 
       - name: gravidade_score
         description: >
-          Score final, em "dias de atraso", já com o multiplicador de gestante
-          aplicado. Igual a gravidade_score_base * 2 quando gestante = TRUE,
-          caso contrário igual a gravidade_score_base.
+          Score final (FLOAT64), em soma de subscores NORMALIZADOS, já com o
+          multiplicador de gestante aplicado. Igual a gravidade_score_base * 2
+          quando gestante = TRUE, caso contrário igual a gravidade_score_base.
         data_tests:
           - not_null:
               name: mart_monitora_cancer__gravidade__gravidade_score__not_null
 
       - name: gravidade_score_base
         description: >
-          Soma das parcelas de dias_atraso de todos os subscores, ANTES da
-          multiplicação por gestante. Útil para auditoria e comparação direta
-          entre pacientes gestantes e não-gestantes.
+          Soma dos subscores NORMALIZADOS
+          (subscore_valor_normalizado = subscore_valor
+                                      / ( max_risco
+                                          * 2 ^ (teto_atraso / dias_dobrar_subscore) ))
+          de todos os triggers ATIVOS de todos os subscores, ANTES da
+          multiplicação por gestante. Tipo FLOAT64. Cada trigger ativo
+          contribui com um valor em (0, 1] — perto de 0 quando o atraso é
+          pequeno e o risco baixo, próximo de 1 quando o atraso satura em
+          teto_atraso e risco_trigger = max_risco. Útil para auditoria e
+          comparação direta entre pacientes gestantes e não-gestantes.
 
       - name: gestante
         description: >
@@ -533,9 +561,17 @@ models:
 
       - name: gravidade_breakdown
         description: >
-          Array de structs detalhando cada parcela do score, ordenado por
-          data_trigger desc. Cada struct contém: subscore (identificador
-          textual do par trigger/expected), data_trigger (data de referência
-          do evento gatilho), data_expected (data de execução/autorização do
-          desfecho esperado encontrado, ou NULL quando ainda não aconteceu)
-          e dias_atraso (parcela contribuída por aquele trigger ao score).
+          Array de structs detalhando cada subscore ATIVO que compõe o score,
+          ordenado por data_trigger desc. Triggers cujo expected já chegou
+          não aparecem aqui (foram desativados). Cada struct contém:
+          subscore (identificador textual do par trigger/expected),
+          data_trigger (data de referência do evento gatilho), dias_atraso
+          (dias desde o trigger até hoje, descontado o threshold, com piso
+          0 e teto-limitado em teto_atraso pela fórmula do subscore),
+          dias_dobrar_subscore (parâmetro da fórmula exponencial — a cada N
+          dias de atraso, o termo exponencial dobra), risco_trigger (risco
+          do evento gatilho, 1..4 ou NULL — alimenta o fator de risco
+          coalesce(risco_trigger, 1)), subscore_valor (valor BRUTO do
+          subscore para aquele trigger) e subscore_valor_normalizado (valor
+          do subscore dividido pelo máximo teórico — em (0, 1], é o que
+          entra na soma do gravidade_score).

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__fatos.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__fatos.sql
@@ -155,7 +155,7 @@ with
             atraso_autorizacao_execucao,
             atraso_regulacao,
 
-        -- risco do evento (float64, 1.0-4.0 ou NULL); mapeamento por sistema feito nos int_*
+        -- risco do evento (1-4 ou NULL); mapeamento por sistema feito nos int_*
             risco,
 
         -- unidade solicitante

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__fatos.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__fatos.sql
@@ -88,7 +88,8 @@ with
             criterio_diagnostico,
             atraso_solicitacao_autorizacao,
             atraso_autorizacao_execucao,
-            atraso_regulacao
+            atraso_regulacao,
+            safe_cast(risco as int) as risco
         from fontes_unificadas
     ),
 
@@ -153,6 +154,9 @@ with
             atraso_solicitacao_autorizacao,
             atraso_autorizacao_execucao,
             atraso_regulacao,
+
+        -- risco do evento (float64, 1.0-4.0 ou NULL); mapeamento por sistema feito nos int_*
+            risco,
 
         -- unidade solicitante
             id_cnes_unidade_origem,

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -83,6 +83,8 @@ select
             ev.atraso_autorizacao_execucao,
             ev.atraso_regulacao,
 
+            ev.risco,
+
             ev.dias_proximo_evento,
             ev.run_id as jornada_id
         )


### PR DESCRIPTION
Introduce a per-event risco attribute to the monitora_cancer mart and enhance subscore calculations before summation. This improves the accuracy of risk assessments in cancer monitoring.