### PR TITLE
Inclui exceções no mart de alta maternidade

### DIFF
--- a/models/marts/iplanrio/whatsapp/_mart_iplanrio__sisare_alta_maternidade.yml
+++ b/models/marts/iplanrio/whatsapp/_mart_iplanrio__sisare_alta_maternidade.yml
@@ -1,5 +1,16 @@
 version: 2
 
+sources:
+  - name: projeto_whatsapp
+    database: rj-sms
+    schema: projeto_whatsapp
+    tables:
+      - name: excecao_disparo_puerperas
+        description: >
+          Tabela de exceções operacionais para inclusão manual de puérperas na régua de disparos
+          do projeto Cegonha Digital. Possui o mesmo schema da tabela sisare_alta_maternidade
+          para permitir união no modelo final sem expor dados pessoais no repositório.
+
 models:
   - name: mart_iplanrio__sisare_alta_maternidade
     description: >

--- a/models/marts/iplanrio/whatsapp/mart_iplanrio__sisare_alta_maternidade.sql
+++ b/models/marts/iplanrio/whatsapp/mart_iplanrio__sisare_alta_maternidade.sql
@@ -176,7 +176,28 @@ final as (
         id_desfecho_gestacao,
         desfecho_gestacao
 
+),
+
+excecao_disparo_puerperas as (
+
+    select
+        cpf,
+        nome,
+        data_alta_internacao,
+        cnes_maternidade_alta,
+        nome_maternidade_alta,
+        data_parto,
+        id_desfecho_gestacao,
+        desfecho_gestacao,
+        telefones_gestante
+    from {{ source("projeto_whatsapp", "excecao_disparo_puerperas") }}
+
 )
 
 select *
 from final
+
+union all
+
+select *
+from excecao_disparo_puerperas


### PR DESCRIPTION
Inclui tabela de exceções no modelo sisare_alta_maternidade para permitir uma entrada específica de registro operacional que não veio do SISARE.