### PR TITLE
ProntuaRio - Implementa nova lógica de materialização do modelo de evolução

### DIFF
--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__alta_clinica.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__alta_clinica.sql
@@ -2,7 +2,8 @@
     config(
         alias="alta_clinica",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         schema="brutos_prontuario_prontuaRio",
         partition_by={
@@ -101,6 +102,14 @@ final as (
 )
 
 select 
+  {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prontuario',
+        ]
+      )
+    }} as id,
   concat(cnes, '.', id_prontuario) as gid_prontuario,
   concat(cnes, '.', id_clinica) as gid_clinica,
   concat(cnes, '.', id_leito) as gid_leito,

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__cen62.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__cen62.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="cen62",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -116,6 +117,14 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_boletim) as gid_boletim,
     *
 from final

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__emergencia_resumo.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__emergencia_resumo.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="emergencia_resumo",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -197,6 +198,15 @@ with
   )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim',
+            'id_prontuario'
+        ]
+      )
+    }} as id,
   concat(cnes,'.',id_boletim) as gid_boletim,
   concat(cnes,'.',id_prontuario) as gid_prontuario,
   *

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="internacao",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -135,6 +136,15 @@ with
  )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prontuario',
+            'id_boletim'
+        ]
+      )
+    }} as id,
   concat(cnes, '.', id_prontuario) as gid_prontuario,
   concat(cnes, '.', id_boletim) as gid_boletim,
   *

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao_alta.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao_alta.sql
@@ -3,7 +3,8 @@
         schema="brutos_prontuario_prontuaRio",
         alias="internacao_alta",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -189,6 +190,14 @@ final as (
 )
 
  select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prontuario'
+        ]
+      )
+    }} as id,
   concat(cnes, '.', id_prontuario) as gid_prontuario,
   *
  from final

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao_cadastro.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__internacao_cadastro.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="internacao_cadastro",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -123,6 +124,15 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prontuario1',
+            'id_registro'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_prontuario1) as gid_prontuario,
     concat(cnes, '.', id_registro) as gid_registro,
     *

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__profissionais.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__profissionais.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="profissionais",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -68,6 +69,14 @@ final as (
 
 
 select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'cpf'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', cpf) as gid_profissional,
     *
 from final

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__profissional_atividade.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__profissional_atividade.sql
@@ -2,8 +2,7 @@
     config(
         schema='brutos_prontuario_prontuaRio',
         alias="profissional_atividade",
-        materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        materialized="table",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",

--- a/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__triagem.sql
+++ b/models/raw/prontuario_prontuaRio/openbase/raw_prontuario_prontuaRio__triagem.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="triagem",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -159,6 +160,16 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_internacao',
+            'id_boletim',
+            'id_receituario'
+        ]
+      )
+    }} as id,
   concat(cnes, '.', id_boletim) as gid_boletim,
   concat(cnes, '.', id_internacao) as gid_internacao,
   concat(cnes, '.', id_receituario) as gid_receituario,

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__atendimento.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__atendimento.sql
@@ -3,8 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="atendimento",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
-        unique_key="id_prontuario",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -141,6 +141,14 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_atendimento'
+        ]
+      )
+    }} as id,
   concat(cnes, '.', id_atendimento) as gid_atendimento,
   concat(cnes, '.', id_paciente) as gid_paciente,
   *

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__emergencia.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__emergencia.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="emergencia",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -63,6 +64,14 @@ with
     )
 
 select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_boletim) as gid_boletim,
     *
 from final

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
@@ -19,21 +19,25 @@
 with 
 
 /*
-  Caso seja necessário rodar o modelo em modo --full-refresh é preciso executar o comando abaixo: 
-  $ dbt run -s raw_prontuario_prontuaRio__evolucao --full-refresh --vars '{"start_date": "2026-05-20", "end_date": "2026-05-20"}'
+  Ao executar o run/build com --full-refresh sem a lógica abaixo, é gerado um erro de uso de memória.
+  Isso acontece devido ao conteúdo presente no campo `descricao` que contém extensos formulários em html.
+  Para contornar este problema restringimos a execução para rodar apenas com dados extraídos no primeiro 
+  dia de extração do ProntuaRio (20/05/2026).
 
-  Depois é necessário ir executando dia a dia em modo incremental para não sobrecarregar o processamento de dados.
-  As primeiras extrações dos arquivos mais antigos foram feitas do dia 20/05/2026 até o dia 25/05/2026 
+  Os dados históricos (backup de novembro/2025) foram extraídos do dia 20/05/2026 até o dia 25/05/2026.
+  Dessa forma, para processa-los é necessário executar uma materialização utilizando os parâmetros abaixo:
 
   $ dbt run -s raw_prontuario_prontuaRio__evolucao --vars '{"start_date": "2026-05-21", "end_date": "2026-05-21"}'
-    
-  Quando for executar o modelo em modo incremental, ele irá considerar a data da última partição processada para buscar os dados 
-  a partir dela até a data atual.
+
+  A indicação é que seja feita dia a dia (até o dia 25/05/2026)
 */
 
     source_ as (
         select * from {{ source('brutos_prontuario_prontuaRio_staging', 'hp_rege_evolucao') }}
         {% if not is_incremental() %}
+        /*
+
+        */
           where date(loaded_at) between date('2026-05-20') and date('2026-05-20') -- Primeira extração do ProntuaRio
         {% endif %}
         {% if is_incremental() %} 

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="evolucao",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -16,42 +17,60 @@
 {% set last_partition = get_last_partition_date(this) %}
 
 with 
+
+/*
+  Caso seja necessário rodar o modelo em modo --full-refresh é preciso executar o comando abaixo: 
+  $ dbt run -s raw_prontuario_prontuaRio__evolucao --full-refresh --vars '{"start_date": "2026-05-20", "end_date": "2026-05-20"}'
+
+  Depois é necessário ir executando dia a dia em modo incremental para não sobrecarregar o processamento de dados.
+  As primeiras extrações dos arquivos mais antigos foram feitas do dia 20/05/2026 até o dia 25/05/2026 
+
+  $ dbt run -s raw_prontuario_prontuaRio__evolucao --vars '{"start_date": "2026-05-21", "end_date": "2026-05-21"}'
+    
+  Quando for executar o modelo em modo incremental, ele irá considerar a data da última partição processada para buscar os dados 
+  a partir dela até a data atual.
+*/
+
     source_ as (
-    select * from {{source('brutos_prontuario_prontuaRio_staging', 'hp_rege_evolucao') }}
-    {% if is_incremental() %} 
-      where cast(loaded_at as date) >= date( '{{ last_partition }}' ) 
-    {% endif %}
+        select * from {{ source('brutos_prontuario_prontuaRio_staging', 'hp_rege_evolucao') }}
+        {% if not is_incremental() %}
+          where date(loaded_at) between date('2026-05-20') and date('2026-05-20') -- Primeira extração do ProntuaRio
+        {% endif %}
+        {% if is_incremental() %} 
+            where date(loaded_at) between date('{{ var("start_date", last_partition) }}')
+                and date('{{ var("end_date", run_started_at.strftime("%Y-%m-%d")) }}')
+        {% endif %}
     ),
 
     evolucao as (
         select
-            json_extract_scalar(data, '$.id') as id_prontuario,
-            json_extract_scalar(data, '$.id_be') as id_boletim,
-            json_extract_scalar(data, '$.cns') as cns,
-            json_extract_scalar(data, '$.registro') as registro, 
-            json_extract_scalar(data, '$.data_reg') as registro_data,
-            json_extract_scalar(data, '$.data_evo') as evolucao_data,
-            json_extract_scalar(data, '$.profissional') as nome_profissional,
-            json_extract_scalar(data, '$.id_profissional') as id_profissional, -- CPF?
-            json_extract_scalar(data, '$.descricao') as descricao, 
-            json_extract_scalar(data, '$.tipo') as tipo,
-            json_extract_scalar(data, '$.data_atu') as atualizacao_data,
-            json_extract_scalar(data, '$.id_cen38') as id_cen38,
-            json_extract_scalar(data, '$.id_am12') as id_am12,
-            json_extract_scalar(data, '$.id_cen02') as id_cen02,
-            json_extract_scalar(data, '$.id_cen54') as id_cen54,
-            json_extract_scalar(data, '$.id_outro') as id_outro,
-            json_extract_scalar(data, '$.tip_outro') as tip_outro,
-            json_extract_scalar(data, '$.status_evol') as status_evolucao,
+            json_extract_scalar(data, '$.id')               as id_prontuario,
+            json_extract_scalar(data, '$.id_be')            as id_boletim,
+            json_extract_scalar(data, '$.cns')              as cns,
+            json_extract_scalar(data, '$.registro')         as registro, 
+            json_extract_scalar(data, '$.data_reg')         as registro_data,
+            json_extract_scalar(data, '$.data_evo')         as evolucao_data,
+            json_extract_scalar(data, '$.profissional')     as nome_profissional,
+            json_extract_scalar(data, '$.id_profissional')  as id_profissional,
+            json_extract_scalar(data, '$.descricao')        as descricao_raw, -- processa depois
+            json_extract_scalar(data, '$.tipo')             as tipo,
+            json_extract_scalar(data, '$.data_atu')         as atualizacao_data,
+            json_extract_scalar(data, '$.id_cen38')         as id_cen38,
+            json_extract_scalar(data, '$.id_am12')          as id_am12,
+            json_extract_scalar(data, '$.id_cen02')         as id_cen02,
+            json_extract_scalar(data, '$.id_cen54')         as id_cen54,
+            json_extract_scalar(data, '$.id_outro')         as id_outro,
+            json_extract_scalar(data, '$.tip_outro')        as tip_outro,
+            json_extract_scalar(data, '$.status_evol')      as status_evolucao,
             json_extract_scalar(data, '$.ds_sub_atividade') as descricao_sub_atividade,
             json_extract_scalar(data, '$.co_sub_atividade') as id_sub_atividade,
-            json_extract_scalar(data, '$.co_atividade') as id_atividade,
-            json_extract_scalar(data, '$.codclin') as id_clinica,
-            json_extract_scalar(data, '$.setor') as setor,
-            json_extract_scalar(data, '$.cid_evo') as cid_evolucao,
-            json_extract_scalar(data, '$.cid_descricao') as cid_descricao,
-            json_extract_scalar(data, '$.proc_evo') as proc_evo,
-            json_extract_scalar(data, '$.proc_descricao') as proc_descricao,
+            json_extract_scalar(data, '$.co_atividade')     as id_atividade,
+            json_extract_scalar(data, '$.codclin')          as id_clinica,
+            json_extract_scalar(data, '$.setor')            as setor,
+            json_extract_scalar(data, '$.cid_evo')          as cid_evolucao,
+            json_extract_scalar(data, '$.cid_descricao')    as cid_descricao,
+            json_extract_scalar(data, '$.proc_evo')         as proc_evo,
+            json_extract_scalar(data, '$.proc_descricao')   as proc_descricao,
             cnes,
             loaded_at
         from source_
@@ -59,50 +78,63 @@ with
 
     final as (
         select
-            safe_cast(id_prontuario as int64) as id_prontuario, 
-            safe_cast(id_boletim as int64) as id_boletim,
-            safe_cast(registro as int64) as registro,
-            {{ process_null('cns') }} as cns,
+            safe_cast(id_prontuario as int64)   as id_prontuario, 
+            safe_cast(id_boletim as int64)      as id_boletim,
+            safe_cast(registro as int64)        as registro,
+            {{ process_null('cns') }}           as cns,
             safe_cast(evolucao_data as datetime) as evolucao_data,
             safe_cast(registro_data as datetime) as registro_data,
             {{ process_null('nome_profissional') }} as nome_profissional,
             case 
-                when id_profissional like '%000%'
-                    then cast(null as string)
-                when id_profissional = '0'
-                    then cast(null as string)
+                when id_profissional like '%000%' then cast(null as string)
+                when id_profissional = '0'        then cast(null as string)
                 else {{ process_null('id_profissional') }}
             end as cpf_profissional,
-            {{ remove_html('descricao') }} as descricao,
-            {{ process_null('tipo') }} as tipo,
+            {{ remove_html('descricao_raw') }}  as descricao, -- aplicado após dedup
+            {{ process_null('tipo') }}          as tipo,
             safe_cast(atualizacao_data as datetime) as atualizacao_data,
-            {{ process_null('id_cen38') }} as id_cen38,
-            {{ process_null('id_am12') }} as id_am12,
-            {{ process_null('id_cen02') }} as id_cen02,
-            {{ process_null('id_cen54') }} as id_cen54,
-            {{ process_null('id_outro') }} as id_outro,
-            {{ process_null('tip_outro') }} as tip_outro,
+            {{ process_null('id_cen38') }}      as id_cen38,
+            {{ process_null('id_am12') }}       as id_am12,
+            {{ process_null('id_cen02') }}      as id_cen02,
+            {{ process_null('id_cen54') }}      as id_cen54,
+            {{ process_null('id_outro') }}      as id_outro,
+            {{ process_null('tip_outro') }}     as tip_outro,
             {{ process_null('status_evolucao') }} as status_evolucao,
             {{ process_null('descricao_sub_atividade') }} as descricao_sub_atividade,
             {{ process_null('id_sub_atividade') }} as id_sub_atividade,
-            {{ process_null('id_atividade') }} as id_atividade,
-            {{ process_null('id_clinica') }} as id_clinica,
-            {{ process_null('setor') }} as setor,
-            {{ process_null('cid_evolucao') }} as cid_evolucao,
+            {{ process_null('id_atividade') }}  as id_atividade,
+            {{ process_null('id_clinica') }}    as id_clinica,
+            {{ process_null('setor') }}         as setor,
+            {{ process_null('cid_evolucao') }}  as cid_evolucao,
             {{ process_null('cid_descricao') }} as cid_descricao,
-            {{ process_null('proc_evo') }} as proc_evo,
+            {{ process_null('proc_evo') }}      as proc_evo,
             {{ process_null('proc_descricao') }} as proc_descricao,
             cnes,
-            loaded_at,
-            cast(loaded_at as date) as data_particao
+            loaded_at
         from evolucao
-        qualify row_number() over(partition by id_prontuario, id_boletim, registro, cnes order by loaded_at desc) = 1
-
+        {% if not is_incremental() %}
+        qualify row_number() over(
+            partition by id_prontuario, id_boletim, registro, cnes 
+            order by loaded_at desc
+        ) = 1
+        {% endif %}
     )
 
 select 
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                'cnes',
+                'id_prontuario',
+                'id_boletim',
+                'registro',
+                'evolucao_data'
+            ]
+    )
+    }} as id,
     concat(cnes, '.', id_prontuario) as gid_prontuario,
-    concat(cnes, '.', id_boletim) as gid_boletim,
-    concat(cnes, '.', registro) as gid_registro, 
-    *
+    concat(cnes, '.', id_boletim)   as gid_boletim,
+    concat(cnes, '.', registro)     as gid_registro, 
+    *,
+    cast(loaded_at as date) as data_particao
 from final

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
@@ -113,12 +113,10 @@ with
             cnes,
             loaded_at
         from evolucao
-        {% if not is_incremental() %}
         qualify row_number() over(
             partition by id_prontuario, id_boletim, registro, cnes 
             order by loaded_at desc
         ) = 1
-        {% endif %}
     )
 
 select 

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__evolucao.sql
@@ -35,9 +35,6 @@ with
     source_ as (
         select * from {{ source('brutos_prontuario_prontuaRio_staging', 'hp_rege_evolucao') }}
         {% if not is_incremental() %}
-        /*
-
-        */
           where date(loaded_at) between date('2026-05-20') and date('2026-05-20') -- Primeira extração do ProntuaRio
         {% endif %}
         {% if is_incremental() %} 

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__medicamento.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__medicamento.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="medicamento",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -83,6 +84,15 @@ with
     )
 
 select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prescricao',
+            'id_medicamento'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_prescricao) as gid_prescricao,
     concat(cnes, '.', id_medicamento) as gid_medicamento,
     *

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__medico.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__medico.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="medico",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -51,6 +52,14 @@ final as (
 
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'cpf'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', cpf) as gid_medico,
     *,
 from final

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__paciente.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__paciente.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="paciente",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -53,6 +54,15 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_paciente',
+            'registro'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_paciente) as gid_paciente,
     concat(cnes, '.', registro) as gid_registro,
     *,

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__prescricao.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__prescricao.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="prescricao",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -60,6 +61,15 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_prescricao',
+            'id_atendimento'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_prescricao) as gid_prescricao,
     concat(cnes, '.', id_atendimento) as gid_atendimento,
     * 

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__prontuario_be.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__prontuario_be.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="prontuario_be",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -45,6 +46,15 @@ with
     )
 
 select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim',
+            'id_prontuario'
+        ]
+      )
+    }} as id,  
   concat(cnes, '.', id_prontuario) as gid_prontuario,
   concat(cnes, '.', id_boletim) as gid_boletim,
   *

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__ralta.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__ralta.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="ralta",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",  
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -65,6 +66,16 @@ with
   )
 
 select
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim',
+            'id_alta',
+            'id_prontuario'
+        ]
+      )
+  }} as id,
   concat(cnes, '.', id_alta) as gid_alta,
   concat(cnes, '.', id_prontuario) as gid_prontuario,
   concat(cnes, '.', id_boletim) as gid_boletim,

--- a/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__receituario.sql
+++ b/models/raw/prontuario_prontuaRio/postgres/raw_prontuario_prontuaRio__receituario.sql
@@ -3,7 +3,8 @@
         schema='brutos_prontuario_prontuaRio',
         alias="receituario",
         materialized="incremental",
-        incremental_strategy="insert_overwrite",
+        incremental_strategy="merge",
+        unique_key="id",
         tags=["prontuaRio"],
         partition_by={
             "field": "data_particao",
@@ -64,6 +65,16 @@ final as (
 )
 
 select 
+    {{
+      dbt_utils.generate_surrogate_key(
+        [
+            'cnes',
+            'id_boletim',
+            'id_receituario',
+            'id_prontuario'
+        ]
+      )
+    }} as id,
     concat(cnes, '.', id_receituario) as gid_receituario,
     concat(cnes, '.', id_prontuario) as gid_prontuario,
     concat(cnes, '.', id_boletim) as gid_boletim,


### PR DESCRIPTION
Este PR implementa as seguintes alterações

## 1. Adiciona uma lógica na materialização --full-refresh do modelo `raw_prontuario_prontuaRio__evolucao`

Este modelo quando materializado com a flag --full-refresh está gerando um problema no uso de memória. 

```
Resources exceeded during query execution: The query could not be executed in the allotted memory. 
Peak usage: 104% of limit.
Top memory consumer(s):
  other/unattributed: 100%
```

Este erro é gerado devido ao conteúdo dentro do campo `descricao` que contem extensos formulários em html e que em alguns casos pode conter arquivos em base64 também.

**A solução implementada é**: Quando o modelo for executado com `--full-refresh`, apenas uma parte dos dados serão utilizados para a materialização (dados extraídos no primeiro dia de extração do ProntuaRio - 20/05/2026). Já para as execuções incrementais, é possível executar "materializações em lote" a partir da variável criada neste modelo.

Para isso, é necessário executar a materialização da seguinte forma:

```bash
dbt run -s raw_prontuario_prontuaRio__evolucao \
--vars '{"start_date": "2026-05-21", "end_date": "2026-05-21"}'
``` 

As extrações dos backups históricos ocorreram do dia 20/05/2026 até 25/05/2026. 
Dessa forma, talvez seja necessário executar materializações dia a dia dentro desse intervalo após uma execução com full-refresh. 

Para execuções diárias, o problema acima não deve ocorrer tendo em vista que os backups recentes tem uma quantidade menor de dados (menos unidades).

## 2. Troca a estratégia incremental dos modelos

A estratégia incremental anterior (`insert_overwrite`) apagava a partição inteira para adicionar o novo conteúdo. Isto estava deletando registros dos dados históricos (backup de novembro/2025) e sobrescrevendo com dados de 2026. Com a estratégia atual, ambos os registros são mantidos. 