### PR TITLE
(Ficha A) Corrige data type do loaded_at

### DIFF
--- a/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_continuo.sql
+++ b/models/raw/prontuario_vitacare/base/base_prontuario_vitacare__ficha_a_continuo.sql
@@ -171,7 +171,7 @@ with
             end as crianca_matriculada_creche_pre_escola,
 
             cast(nullif(source_updated_at, '') as datetime) as updated_at,
-            cast(datalake_loaded_at as string) as loaded_at
+            cast(datalake_loaded_at as datetime) as loaded_at
 
         from latest_events
     )


### PR DESCRIPTION
Semana passada fiz alguns ajustes nos modelos vitacare_historico, alterando o tipo do campo `loaded_at` de STRING para DATETIME

No modelo contínuo, esse campo ainda estava sendo tratado como STRING, o que fazia o UNION ALL falhar com o erro:
`Column 70 in UNION ALL has incompatible types: DATETIME, STRING at [26:9]`

Ajustei removendo o CAST para STRING, mantendo o campo como DATETIME para compatibilizar com o histórico e rodar o UNION