### PR TITLE
[monitora cancer] feat: add diagnosis-time metrics to pacientes_linha_tempo; update docs.

### DIFF
--- a/models/intermediate/subgeral/monitora_cancer/eventos/README.md
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/README.md
@@ -4,5 +4,5 @@ Compute compartilhado por paciente.
 
 | Modelo | Papel |
 |---|---|
-| `int_monitora_cancer__eventos_episodios` | Tabela compartilhada por `mart__gravidade` e `mart__pacientes_linha_tempo` (materializada para evitar trabalho duplo). Calcula o `run_id` (episódio de cuidado, gap ≤ 180 dias). |
+| `int_monitora_cancer__eventos_episodios` | Tabela compartilhada por `mart__gravidade` e `mart__pacientes_linha_tempo` (materializada para evitar trabalho duplo). Calcula o `run_id` (episódio de cuidado, gap ≤ 180 dias) e os tempos por paciente broadcast em cada linha: `tempo_total` e, no run atual, `tempo_diagnostico` e `tempo_diagnostico_sem_tratamento`. |
 | `int_monitora_cancer__pendencias` | Deriva rótulos de pendência por paciente a partir de `eventos_episodios`. |

--- a/models/intermediate/subgeral/monitora_cancer/eventos/_eventos__schema.yml
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/_eventos__schema.yml
@@ -5,8 +5,8 @@ models:
     description: >
       Eventos da população-alvo em forma longa, com janelas temporais
       (dias_proximo_evento), identificador de episódio de cuidado (run_id)
-      e agregado de tempo total da jornada (tempo_total) broadcasted em
-      cada linha.
+      e agregados de tempo da jornada (tempo_total, tempo_diagnostico,
+      tempo_diagnostico_sem_tratamento) broadcasted em cada linha.
 
       Episódios ("runs"): sequências consecutivas de eventos da mesma
       paciente cujos gaps entre data_referencia_evento não excedem
@@ -17,6 +17,9 @@ models:
       contém o primeiro SER até a data desse primeiro SER (proxy do tempo
       decorrido até a entrada em UNACON); para pacientes sem SER, dias
       do início da última run até a data atual.
+
+      tempo_diagnostico e tempo_diagnostico_sem_tratamento: tempos da jornada
+      medidos no run atual (run_id = max(run_id)); ver a descrição de cada coluna.
 
       Granularidade: 1 linha por evento (mesma de mart_monitora_cancer__fatos
       restrita à população-alvo, via LEFT JOIN de pop em fatos por
@@ -248,6 +251,20 @@ models:
           SER, dias do início da última run até hoje. NULL quando o
           cálculo resulta em 0 (mesmo dia). Broadcasted: mesmo valor em
           todas as linhas de uma paciente.
+        data_type: int64
+
+      - name: tempo_diagnostico
+        description: >
+          Dias, no run atual, do início do run (data_solicitacao mais antiga)
+          até o 1º evento que vira DIAGNOSTICO/UNACON (criterio_diagnostico OU
+          fonte = 'SER'). >= 0 por construção; NULL em SUSPEITA. Broadcasted.
+        data_type: int64
+
+      - name: tempo_diagnostico_sem_tratamento
+        description: >
+          Dias, no run atual, do 1º diagnóstico confirmado (criterio_diagnostico)
+          até a 1ª solicitação SER. NULL quando não há diagnóstico em/antes do
+          SER — só assume valor para UNACON. Broadcasted.
         data_type: int64
 
   - name: int_monitora_cancer__pendencias

--- a/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__eventos_episodios.sql
@@ -2,7 +2,8 @@
 
 -- Eventos de monitoramento de câncer de mama em forma longa, com janelas
 -- temporais (dias_proximo_evento), identificador de episódio (run_id) e
--- agregado por paciente (tempo_total) broadcast em cada linha.
+-- agregados por paciente (tempo_total, tempo_diagnostico,
+-- tempo_diagnostico_sem_tratamento) broadcast em cada linha.
 --
 -- Episódios ("runs"): sequências consecutivas de eventos cujos gaps entre
 -- data_referencia_evento não excedem `episodio_gap_dias` (default 180 dias).
@@ -12,6 +13,14 @@
 --   - pacientes com SER: dias do início da run que contém o primeiro SER até
 --     a data desse primeiro SER;
 --   - pacientes sem SER: dias do início da última run até a data atual.
+--
+-- tempo_diagnostico / tempo_diagnostico_sem_tratamento: medidos no run atual
+-- (run_id = max(run_id), como int_monitora_cancer__eventos_run_atual):
+--   - tempo_diagnostico: dias do início do run atual até o 1º evento que vira
+--     DIAGNOSTICO/UNACON (criterio_diagnostico OU fonte = 'SER'). NULL em SUSPEITA.
+--   - tempo_diagnostico_sem_tratamento: dias do 1º diagnóstico confirmado
+--     (criterio_diagnostico) até a 1ª solicitação SER. NULL sem diagnóstico
+--     em/antes do SER (só assume valor para UNACON).
 --
 -- Granularidade: 1 linha por evento (mesma granularidade de mart_monitora_cancer__fatos
 -- restrita à população-alvo).
@@ -220,6 +229,101 @@ with
             left join run_starts as rs_ser
             on psi.cpf_particao = rs_ser.cpf_particao
             and psi.primeira_ser_run_id = rs_ser.run_id
+    ),
+
+    -- Run atual (run_id = max(run_id)). Replica int_monitora_cancer__eventos_run_atual
+    -- (downstream deste — evita ciclo). Base dos tempos de diagnóstico abaixo.
+    eventos_run_atual as (
+        select *
+        from eventos_com_run
+        qualify run_id = max(run_id) over (partition by cpf_particao)
+    ),
+
+    -- Início do run atual: data_solicitacao mais antiga (mesmo marcador de run_starts).
+    run_atual_start as (
+        select
+            cpf_particao,
+            min(data_solicitacao) as run_atual_start_data
+        from eventos_run_atual
+        group by cpf_particao
+    ),
+
+    -- 1º evento do run atual que vira DIAGNOSTICO/UNACON (criterio_diagnostico OU SER).
+    marco_diagnostico_run_atual as (
+        select
+            cpf_particao,
+            data_referencia_evento as marco_data
+        from eventos_run_atual
+        where criterio_diagnostico = true or fonte = 'SER'
+            qualify row_number() over evento_order = 1
+            window evento_order as (
+                partition by cpf_particao
+                order by -- event_order
+                    data_referencia_evento,
+                    data_solicitacao,
+                    data_autorizacao,
+                    data_execucao,
+                    data_resultado
+            )
+    ),
+
+    -- 1º diagnóstico confirmado do run atual (criterio_diagnostico).
+    diagnostico_run_atual as (
+        select
+            cpf_particao,
+            data_referencia_evento as diagnostico_data
+        from eventos_run_atual
+        where criterio_diagnostico = true
+            qualify row_number() over evento_order = 1
+            window evento_order as (
+                partition by cpf_particao
+                order by -- event_order
+                    data_referencia_evento,
+                    data_solicitacao,
+                    data_autorizacao,
+                    data_execucao,
+                    data_resultado
+            )
+    ),
+
+    -- 1ª solicitação SER do run atual.
+    ser_run_atual as (
+        select
+            cpf_particao,
+            data_solicitacao as primeira_ser_data
+        from eventos_run_atual
+        where fonte = 'SER'
+            qualify row_number() over evento_order = 1
+            window evento_order as (
+                partition by cpf_particao
+                order by -- event_order
+                    data_referencia_evento,
+                    data_solicitacao,
+                    data_autorizacao,
+                    data_execucao,
+                    data_resultado
+            )
+    ),
+
+    -- Broadcast por paciente. Dirigida por marco_diagnostico_run_atual: quem não
+    -- tem marco no run atual (SUSPEITA) não entra e fica NULL via LEFT JOIN final.
+    tempos_diagnostico_por_paciente as (
+        select
+            mdr.cpf_particao,
+            -- (i) >= 0 por construção (o marco está no run que começa no min da solicitação)
+            date_diff(mdr.marco_data, ras.run_atual_start_data, day) as tempo_diagnostico,
+            -- (ii) NULL quando não há diagnóstico em/antes do SER
+            if(
+                dxr.diagnostico_data is not null
+                    and ser.primeira_ser_data is not null
+                    and ser.primeira_ser_data >= dxr.diagnostico_data,
+                date_diff(ser.primeira_ser_data, dxr.diagnostico_data, day),
+                null
+            ) as tempo_diagnostico_sem_tratamento
+        from marco_diagnostico_run_atual as mdr
+            left join run_atual_start as ras using (cpf_particao)
+            left join diagnostico_run_atual as dxr using (cpf_particao)
+            left join ser_run_atual as ser using (cpf_particao)
     )
 
 select
@@ -264,7 +368,10 @@ select
     ev.dias_proximo_evento,
     ev.run_id,
 
-    ttp.tempo_total
+    ttp.tempo_total,
+    tdp.tempo_diagnostico,
+    tdp.tempo_diagnostico_sem_tratamento
 
 from eventos_com_run as ev
     left join tempo_total_por_paciente as ttp using (cpf_particao)
+    left join tempos_diagnostico_por_paciente as tdp using (cpf_particao)

--- a/models/marts/subgeral/monitora_cancer/SOBRE.md
+++ b/models/marts/subgeral/monitora_cancer/SOBRE.md
@@ -2,23 +2,23 @@
 
 ## 1. Introdução
 
-O Monitora Câncer é um sistema de acompanhamento da linha de cuidado do câncer de mama na rede municipal de saúde do Rio de Janeiro. Ele cruza informações de três sistemas oficiais para reconstruir a jornada de cada paciente em investigação ou tratamento e ajuda a equipe a priorizar os contatos do dia.
+O Monitora Câncer é um sistema de acompanhamento da linha de cuidado do câncer de mama na rede municipal de saúde do Rio de Janeiro. Ele cruza informações de três sistemas oficiais para reconstruir a jornada de cada pessoa do sexo feminino em investigação ou tratamento e ajuda a equipe a priorizar os contatos do dia.
 
 Este é um produto do **Núcleo de Tecnologia da Informação (NTI)**, vinculado à **Central de Regulação** da **Subsecretaria Geral (SUBGERAL)** da Secretaria Municipal de Saúde do Rio de Janeiro (SMS Rio).
 
 O sistema entrega duas coisas principais:
 
-- uma **fila de urgência de contato**, ordenada por um número (chamado *score de gravidade*) que indica quão urgente é ligar para cada paciente;
-- uma **linha do tempo por paciente**, com todos os eventos registrados e as pendências em aberto.
+- uma **fila de urgência de contato**, ordenada por um número (chamado *score de gravidade*) que indica quão urgente é ligar para cada pessoa;
+- uma **linha do tempo por pessoa**, com todos os eventos registrados e as pendências em aberto.
 
 ```mermaid
 flowchart LR
-    A[SISCAN<br/>laudos de exames]
-    B[SISREG<br/>regulacao municipal]
-    C[SER<br/>regulacao estadual]
-    M[Monitora Cancer]
-    D[Fila de Urgencia<br/>de Contato]
-    E[Linha do Tempo<br/>por Paciente]
+    A[SISCAN<br/>laudos<br/>de exames]
+    B[SISREG<br/>regulação<br/>municipal]
+    C[SER<br/>regulação<br/>estadual]
+    M[Monitora<br/>Câncer]
+    D[Fila de<br/>Urgência<br/>de Contato]
+    E[Linha do<br/>Tempo por<br/>Paciente]
     A --> M
     B --> M
     C --> M
@@ -28,62 +28,62 @@ flowchart LR
 
 ## 2. Objetivo
 
-A equipe da Central de Regulação não consegue ligar para todas as pacientes em monitoramento no mesmo dia. Precisa de uma forma justa de decidir por quem começar.
+As equipes da SMS Rio não conseguem entrar em contato com todas as pessoas em monitoramento no mesmo dia. É preciso uma ferramenta para apoiar as decisões neste processo.
 
-O objetivo do Monitora Câncer é responder, todos os dias, a duas perguntas:
+O objetivo do Monitora Câncer é, portando, responder, todos os dias, a duas perguntas:
 
-1. **Quais pacientes estão em monitoramento agora?**
+1. **Quais pessoas estão em monitoramento agora?**
 2. **Em qual ordem a equipe deve contatá-las?**
 
-A resposta da primeira pergunta sai como uma lista de pacientes com seus dados de contato. A resposta da segunda pergunta sai como um número de 0 a 100 para cada paciente: quanto maior, mais urgente.
+A resposta da primeira pergunta sai como uma lista de pessoas com seus dados de contato. A resposta da segunda pergunta sai como um número de 0 a 100 para cada pessoa: quanto maior, mais urgente.
 
 ## 3. Fontes de Dados
 
 O sistema cruza três fontes oficiais:
 
 - **SISCAN** (Sistema de Informação do Câncer): registra os laudos de exames de mama, como mamografias e biópsias. Traz o resultado clínico, incluindo a categoria BI-RADS - uma classificação padronizada que vai de 0 a 6 e indica o grau de suspeita do exame.
-- **SISREG** (Sistema de Regulação Municipal): registra os pedidos de exames e consultas na rede municipal do Rio. Traz as datas de solicitação, autorização e execução de cada procedimento.
+- **SISREG** (Sistema de Regulação adotado no Município): registra os pedidos de exames e consultas da Atenção Primária à Saúde (APS) da rede municipal do Rio. No Monitora Câncer, são utilizadas as datas de solicitação, autorização e execução de cada procedimento.
 - **SER** (Sistema Estadual de Regulação): registra os encaminhamentos para a alta complexidade oncológica, ou seja, para as **UNACON** (Unidades de Alta Complexidade em Oncologia). É a porta de entrada para o tratamento de câncer.
 
 Cada exame, consulta ou encaminhamento vira uma linha no sistema (um evento). As três fontes alimentam a mesma base de eventos, e o restante da lógica trabalha em cima dela.
 
 ## 4. Lógica de Seleção de Pacientes e de Classificação
 
-### Como uma paciente entra no monitoramento
+### Como uma pessoa entra no monitoramento
 
-Uma paciente entra na lista quando atende, ao mesmo tempo, a todos os critérios abaixo:
+Uma pessoa entra na lista quando atende, ao mesmo tempo, a todos os critérios abaixo:
 
 - é do sexo feminino (registro cadastral);
 - está viva (sem registro de óbito);
 - tem pelo menos um evento registrado a partir de **01/01/2025**;
 - esse evento é considerado de **suspeita** ou de **diagnóstico** de câncer de mama (veja a Seção 5).
 
-### Status da paciente
+### Status da pessoa
 
-Quando uma paciente entra, ela também recebe um **status**. O status diz em que ponto da linha de cuidado ela está:
+Quando uma pessoa entra, ela também recebe um **status**. O status diz em que ponto da linha de cuidado ela está:
 
 - **SUSPEITA**: há indícios em exames ou pedidos de exames, mas o câncer ainda não foi confirmado.
 - **DIAGNÓSTICO**: o câncer foi confirmado por exame (por exemplo, mamografia BI-RADS categoria 6 ou biópsia com lesão neoplásica).
-- **UNACON**: a paciente já foi encaminhada para uma unidade de alta complexidade oncológica - ou seja, tem pelo menos um evento registrado no SER.
+- **UNACON**: a pessoa já foi encaminhada para uma unidade de alta complexidade oncológica - ou seja, tem pelo menos um evento registrado no SER.
 
 A regra de decisão é a seguinte:
 
 ```mermaid
 flowchart TD
-    A[Paciente na populacao-alvo]
-    Q1{Tem pelo menos<br/>um evento no SER?}
-    Q2{Tem algum exame com<br/>diagnostico confirmado?}
+    A[Paciente na<br/>população-alvo]
+    Q1{Tem pelo<br/>menos um<br/>evento<br/>no SER?}
+    Q2{Algum exame<br/>com<br/>diagnóstico<br/>confirmado?}
     R1[UNACON]
-    R2[DIAGNOSTICO]
+    R2[DIAGNÓSTICO]
     R3[SUSPEITA]
     A --> Q1
     Q1 -- sim --> R1
-    Q1 -- nao --> Q2
+    Q1 -- não --> Q2
     Q2 -- sim --> R2
-    Q2 -- nao --> R3
+    Q2 -- não --> R3
 ```
 
-**Exemplo concreto.** Uma paciente faz mamografia e o laudo sai como BI-RADS 4. Ela entra com status SUSPEITA. Em seguida, faz uma biópsia que confirma lesão neoplásica: passa para DIAGNÓSTICO. Quando o pedido de consulta com mastologista oncológico aparece no SER, passa para UNACON.
+**Exemplo:** Uma pessoa faz mamografia e o laudo sai como BI-RADS 4. Ela entra com status SUSPEITA. Em seguida, faz uma biópsia que confirma lesão neoplásica: passa para DIAGNÓSTICO. Quando o pedido de consulta com mastologista oncológico aparece no SER, passa para UNACON.
 
 ## 5. Tabela de Procedimentos Monitorados
 
@@ -129,23 +129,23 @@ Resumo das categorias BI-RADS: 0 = inconclusiva; 1 e 2 = sem sinais suspeitos; 3
 
 ## 6. Critérios de Exclusão
 
-A paciente sai da lista quando uma das regras abaixo se aplica.
+A pessoa sai da lista quando uma das regras abaixo se aplica.
 
 | Regra                             | Quando se aplica |
 |-----------------------------------|------------------|
-| Óbito                             | Quando há registro cadastral de óbito da paciente. |
-| Mamografia BI-RADS 1 ou 2         | Quando o último evento da paciente foi uma mamografia com resultado em categoria 1 ou 2 (sem indícios de câncer). |
-| Duas mamografias BI-RADS 3        | Quando os dois últimos eventos da paciente foram mamografias em categoria 3 (provavelmente benignas). |
+| Óbito                             | Quando há registro cadastral de óbito da pessoa. |
+| Mamografia BI-RADS 1 ou 2         | Quando o último evento da pessoa foi uma mamografia com resultado em categoria 1 ou 2 (sem indícios de câncer). |
+| Duas mamografias BI-RADS 3        | Quando os dois últimos eventos da pessoa foram mamografias em categoria 3 (provavelmente benignas). |
 | Biópsia sem lesão                 | Quando o último evento foi uma biópsia sem lesão neoplásica nem benigna identificada (descarta o achado). |
 | SER antigo                        | Quando o último evento foi um encaminhamento no SER já finalizado há tempo suficiente (veja parâmetros na Seção 8). |
 
-**Observação importante.** As regras de mamografia BI-RADS 1/2, biópsia sem lesão e SER antigo se aplicam apenas ao **último** evento da paciente. Se mais tarde aparecer um evento novo (por exemplo, uma nova mamografia suspeita), a paciente pode voltar para a lista automaticamente.
+**Observação importante:** As regras de mamografia BI-RADS 1 ou 2, biópsia sem lesão e SER antigo se aplicam apenas ao **último** evento da pessoa. Se mais tarde aparecer um evento novo (por exemplo, uma nova mamografia suspeita), a pessoa pode voltar para a lista automaticamente.
 
 ## 7. Procedimentos Monitorados: Visão da Jornada
 
-Os procedimentos da Seção 5 representam etapas típicas da jornada da paciente. Eles podem ser agrupados pela finalidade clínica:
+Os procedimentos da Seção 5 representam etapas típicas da jornada da pessoa. Eles podem ser agrupados pela finalidade clínica:
 
-- **Rastreio**: mamografia de rastreio. Identifica indícios em pacientes sem queixa.
+- **Rastreio**: mamografia de rastreio. Identifica indícios em pessoas sem queixa.
 - **Investigação de suspeita**: mamografia diagnóstica, USG de mamas, RNM de mamas. Detalham um achado.
 - **Confirmação diagnóstica**: biópsia (em vários tipos). Confirma se a lesão é câncer.
 - **Acompanhamento ambulatorial**: consulta em mastologia. Direciona os próximos passos.
@@ -156,10 +156,10 @@ Uma jornada típica atravessa essas etapas mais ou menos nesta ordem:
 ```mermaid
 flowchart LR
     R[Mamografia<br/>de Rastreio]
-    I[Mamografia Diagnostica<br/>USG / RNM]
-    C[Biopsia]
+    I[Mamografia<br/>Diagnóstica<br/>USG / RNM]
+    C[Biópsia]
     M[Consulta em<br/>Mastologia]
-    O[Consulta Oncologica<br/>no SER]
+    O[Consulta<br/>Oncológica<br/>no SER]
     U[UNACON]
     R --> I
     I --> C
@@ -169,7 +169,7 @@ flowchart LR
     O --> U
 ```
 
-O sistema acompanha a paciente em todas essas etapas e dispara alertas quando o tempo entre uma etapa e outra ultrapassa os limites esperados.
+O sistema acompanha a pessoa em todas essas etapas e dispara alertas quando o tempo entre uma etapa e outra ultrapassa os limites esperados.
 
 ## 8. Parâmetros de Tempo
 
@@ -195,35 +195,37 @@ Para cada procedimento, o sistema espera que ele seja autorizado e executado den
 
 | Parâmetro                                  | Valor       | Para que serve |
 |--------------------------------------------|-------------|----------------|
-| Data de corte                              | 01/01/2025  | Eventos anteriores a essa data não contam para entrada da paciente na lista. |
-| Episódio de cuidado                        | 180 dias    | Eventos da mesma paciente separados por mais de 180 dias são tratados como episódios diferentes de cuidado. O sistema considera apenas o episódio mais recente. |
-| Exclusão por SER antigo (status ALTA)      | 3 meses     | Se o último evento da paciente foi um SER com status ALTA há 3 meses ou mais, a paciente sai da lista. |
-| Exclusão por SER antigo (chegada/cancelada)| 6 meses     | Se o último evento foi um SER com status CHEGADA_CONFIRMADA ou CANCELADA há 6 meses ou mais, a paciente sai da lista. |
+| Data de corte                              | 01/01/2025  | Eventos anteriores a essa data não contam para entrada da pessoa na lista. |
+| Episódio de cuidado                        | 180 dias    | Eventos da mesma pessoa separados por mais de 180 dias são tratados como episódios diferentes de cuidado. O sistema considera apenas o episódio mais recente. |
+| Exclusão por SER antigo (status ALTA)      | 3 meses     | Se o último evento da pessoa foi um SER com status ALTA há 3 meses ou mais, a pessoa sai da lista. |
+| Exclusão por SER antigo (chegada/cancelada)| 6 meses     | Se o último evento foi um SER com status CHEGADA_CONFIRMADA ou CANCELADA há 6 meses ou mais, a pessoa sai da lista. |
 | Alerta de prazo legal próximo do limite    | 45 dias     | A partir de 45 dias desde o diagnóstico, o sistema avisa que o prazo legal para início de tratamento está próximo. |
-| Prazo legal para início do tratamento      | 60 dias     | Após o diagnóstico de câncer, a paciente tem direito a iniciar o tratamento em até 60 dias. |
+| Prazo legal para início do tratamento      | 60 dias     | Após o diagnóstico de câncer, a pessoa tem direito a iniciar o tratamento em até 60 dias. |
 
 ### 8.3 Folgas dos critérios do score
 
 Cada critério do score tem uma **folga tolerável** - um número de dias durante o qual a pendência ainda não pesa no score. A lista completa está na Seção 10.
 
+A folga não é um valor arbitrário: ela representa o **tempo dentro do qual se espera que aquele desfecho aconteça** (por exemplo, o prazo razoável para uma biópsia solicitada ser realizada, ou para um encaminhamento ao SER ser autorizado). Enquanto a pendência está dentro desse prazo, ela segue o curso normal e não exige atenção prioritária. Por isso o score só passa a pesar **depois** que a folga é ultrapassada: o objetivo é destacar quem já passou do tempo em que deveria ter recebido a intervenção - ou seja, quem precisa de atenção prioritária.
+
 ## 9. Score de Gravidade
 
 ### O que é
 
-O score de gravidade é um número de 0 a 100 que ordena as pacientes por **urgência de contato**. Quanto maior o número, mais urgente a paciente precisa ser contatada pela equipe.
+O score de gravidade é um número de 0 a 100 que ordena as pessoas por **urgência de contato**. Quanto maior o número, mais urgente a pessoa precisa ser contatada pela equipe.
 
 ### A intuição
 
-O score sobe quando, para uma paciente:
+O score sobe quando, para uma pessoa, acontece uma combinação de fatores como:
 
-- **Há mais pendências em aberto.** Uma pendência é uma tarefa esperando ser feita - por exemplo, biópsia pedida mas ainda não realizada.
-- **As pendências estão paradas há mais tempo.** Cada tipo de pendência tem uma folga tolerável. Passou da folga, começa a pesar.
-- **A pendência é clinicamente mais grave.** Um diagnóstico confirmado pesa mais do que uma suspeita em rastreio.
-- **A paciente está gestante.** Recebe atendimento prioritário.
+- **Há mais pendências em aberto:** Uma pendência é uma tarefa esperando ser feita - por exemplo, biópsia pedida mas ainda não realizada.
+- **As pendências estão paradas há mais tempo:** Cada tipo de pendência tem uma folga tolerável. Passou da folga, começa a pesar.
+- **A pendência é clinicamente mais grave:** Um diagnóstico confirmado pesa mais do que uma suspeita em rastreio.
+- **A pessoa está gestante:** Recebe atendimento prioritário.
 
 ### Exemplo passo a passo
 
-Imagine a paciente Maria. Ela tem duas pendências ativas e está gestante.
+Imagine a pessoa Maria. Ela tem duas pendências ativas e está gestante.
 
 - **Pendência A** - mamografia categoria 6 (diagnóstico confirmado) sem encaminhamento ao SER. Folga: 5 dias. Atraso: 10 dias. Peso clínico: alto.
 - **Pendência B** - solicitação no SER parada no status "pendente". Folga: 10 dias. Atraso: 10 dias. Peso clínico: médio.
@@ -232,15 +234,15 @@ A pendência A pesa muito mais, porque (1) o atraso já é o dobro da folga, (2)
 
 Como a Maria é gestante, a contribuição da pendência mais grave (A) **dobra**. A pendência B continua contribuindo, em menor escala.
 
-Resultado: a Maria fica entre as primeiras da fila do dia, acima de pacientes não gestantes com pendência parecida.
+Resultado: a Maria fica entre as primeiras da fila do dia, acima de pessoas não gestantes com pendência parecida.
 
 ### Como interpretar o score na prática
 
-- **O score serve para ordenar a fila do dia, não para julgar o caso clínico.** Score 80 não significa "doença mais grave que score 50" - significa "a equipe deve ligar antes para esta paciente".
+- **O score serve para ordenar a fila do dia, não para julgar o caso clínico.** Score 80 não significa "doença mais grave que score 50" - significa "a equipe deve ligar antes para esta pessoa".
 - **Use o score como prioridade, não como diagnóstico.** O cuidado clínico continua sendo avaliado caso a caso.
-- **Score 0 não significa "paciente sem problema".** Significa "sem pendência em aberto nesta data". A paciente continua sendo monitorada e pode subir na fila no dia seguinte.
+- **Score 0 não significa "pessoa sem problema".** Significa "sem pendência em aberto nesta data". A pessoa continua sendo monitorada e pode subir na fila no dia seguinte.
 - **Não compare scores entre dias como se fosse evolução clínica.** O sistema recalcula a escala 0-100 todos os dias com base na distribuição daquele dia. Use o score sempre como **posição na fila daquele dia**.
-- **Pacientes gestantes sem pendência em aberto ficam com score 0.** O multiplicador de gestante só atua quando há pendência ativa.
+- **Pessoas gestantes sem pendência em aberto ficam com score 0.** O multiplicador de gestante só atua quando há pendência ativa.
 
 ## 10. Critérios e Parâmetros do Score
 
@@ -258,17 +260,11 @@ O score combina sete critérios. Cada um tem uma folga tolerável (intervalo de 
 
 A calibração dos pesos reflete a hierarquia clínica: **diagnóstico confirmado** (C2, C3) pesa mais do que **encaminhamento em curso** (C5, C6, C7), que pesa mais do que **rastreio em investigação** (C1, C4).
 
-### Outros parâmetros do score
-
-| Parâmetro                | Valor             | O que faz |
-|--------------------------|-------------------|-----------|
-| Peso de carga total      | 0.5               | Controla o quanto "ter várias pendências ao mesmo tempo" pesa no score. |
-| Multiplicador de gestante| 1.0               | Dobra a contribuição da pendência mais grave quando a paciente está gestante. |
-| Amortecimento de risco   | (risco + 1) / 5   | Suaviza a diferença entre risco baixo e risco alto. Com isso, risco máximo (4) vale 2.5 vezes o risco mínimo (1), e não 4 vezes. |
+A definição matemática completa - como esses sete critérios viram um único número de 0 a 100, com a fórmula passo a passo e os parâmetros $\lambda$ (peso de carga total), $\alpha$ (multiplicador de gestante) e o amortecimento de risco - está no **Anexo A**, ao final do documento. Para usar o Monitora Câncer no dia a dia, as Seções 9 e 10 bastam; o Anexo serve a quem precisa auditar ou reproduzir o cálculo exato.
 
 ## 11. Pendências
 
-Pendência é qualquer tarefa clínica esperando ser feita. O sistema mostra as pendências em aberto de cada paciente na linha do tempo. As pendências se dividem em três famílias.
+Pendência é qualquer tarefa clínica esperando ser feita. O sistema mostra as pendências em aberto de cada pessoa na linha do tempo. As pendências se dividem em três famílias.
 
 ### Pendências do SISREG (quando o último evento é do SISREG)
 
@@ -278,7 +274,7 @@ Pendência é qualquer tarefa clínica esperando ser feita. O sistema mostra as 
 | Pendente de realização SISREG   | Procedimento foi autorizado mas ainda não foi executado. |
 | Aguardando execução SISREG      | Procedimento tem data de execução agendada no futuro. |
 | Devolvido SISREG                | Status do procedimento indica devolução. |
-| Falta SISREG                    | Status do procedimento indica falta da paciente. |
+| Falta SISREG                    | Status do procedimento indica falta da pessoa. |
 
 ### Pendências do SER (quando o último evento é do SER)
 
@@ -288,7 +284,7 @@ Pendência é qualquer tarefa clínica esperando ser feita. O sistema mostra as 
 | Pendente de realização SER      | Solicitação foi autorizada mas ainda não foi executada. |
 | Aguardando execução SER         | Solicitação tem data de execução agendada no futuro. |
 | Procedimento cancelado SER      | Solicitação no SER foi cancelada. |
-| Falta SER                       | Paciente não confirmou a chegada (status CHEGADA_NAO_CONFIRMADA). |
+| Falta SER                       | Pessoa não confirmou a chegada (status CHEGADA_NAO_CONFIRMADA). |
 
 ### Pendências de encaminhamento para UNACON (somente para status DIAGNÓSTICO)
 
@@ -296,16 +292,71 @@ Estas três pendências descrevem a mesma situação em níveis de urgência cre
 
 | Pendência                                                | Quando ativa |
 |----------------------------------------------------------|--------------|
-| Pendente de solicitação para UNACON                      | Paciente diagnosticada há menos de 45 dias e ainda sem solicitação SER. |
-| Prazo para início de tratamento próximo do limite legal  | Paciente diagnosticada há 45 dias ou mais e ainda sem solicitação SER. |
-| Prazo legal para início de tratamento ultrapassado       | Paciente diagnosticada há 60 dias ou mais e ainda sem solicitação SER (prazo legal de 60 dias ultrapassado). |
+| Pendente de solicitação para UNACON                      | Pessoa diagnosticada há menos de 45 dias e ainda sem solicitação SER. |
+| Prazo para início de tratamento próximo do limite legal  | Pessoa diagnosticada há 45 dias ou mais e ainda sem solicitação SER. |
+| Prazo legal para início de tratamento ultrapassado       | Pessoa diagnosticada há 60 dias ou mais e ainda sem solicitação SER (prazo legal de 60 dias ultrapassado). |
 
 ## 12. Atualização de Dados
 
 - **Frequência**: o sistema é atualizado **uma vez por dia**, de forma automática.
-- **O que é recalculado**: a lista de pacientes em monitoramento, o status de cada uma, as pendências em aberto e o score de gravidade.
+- **O que é recalculado**: a lista de pessoas em monitoramento, o status de cada uma, as pendências em aberto e o score de gravidade.
 - **Defasagem possível**: o sistema depende dos dados que as fontes (SISCAN, SISREG, SER) já registraram. Se um exame foi realizado mas ainda não foi lançado na sua fonte de origem, ele ainda não aparece aqui.
 - **Identificação da execução**: cada atualização deixa uma marca registrando quando rodou, para auditoria.
+
+## Anexo A - Definição matemática do score
+
+Esta seção detalha o cálculo exato do score descrito nas Seções 9 e 10. Ela é voltada a quem precisa **auditar ou reproduzir** o número e pode ser ignorada por quem só vai usar a fila no dia a dia.
+
+### A fórmula do score
+
+O score é construído em cinco passos. Os parâmetros descritos na tabela ao final desta seção aparecem em destaque na fórmula.
+
+Para cada **critério ativo** $c$ de uma pessoa, usamos quatro quantidades:
+
+- $f_c$ = **folga** (intervalo de urgência) do critério, em dias - coluna *Folga* da tabela de critérios (Seção 10). É o **tempo dentro do qual se espera que aquele desfecho aconteça** (por exemplo, o prazo razoável para uma biópsia ser realizada);
+- $a_c$ = **dias de atraso** além da folga: $a_c = \max\left(0,\ \text{dias desde o gatilho} - f_c\right)$. Descontamos $f_c$ justamente para isolar o tempo que passou **depois** do prazo esperado - ou seja, o quanto a pessoa já está atrasada para a intervenção que deveria ter ocorrido. Dentro da folga, $a_c = 0$ e o critério não pesa;
+- $r_c$ = **risco** do evento que disparou o critério, na escala de 1 a 4 (quando ausente, vale 2). O maior valor possível dessa escala é $r_{\max} = 4$;
+- $w_c$ = **peso clínico** do critério - coluna *Peso* da tabela de critérios (Seção 10).
+
+**1. Gravidade de cada critério** combina o atraso com o risco:
+
+$$g_c \;=\; \underbrace{\frac{a_c}{f_c}}_{\text{fator de tempo}} \;\times\; \underbrace{\frac{r_c + 1}{r_{\max} + 1}}_{\text{fator de risco}}$$
+
+O *fator de tempo* cresce em 1 a cada folga adicional de atraso. O *fator de risco* é o **amortecimento de risco**. O denominador é $r_{\max} + 1$, onde $r_{\max} = 4$ é o maior valor da escala de risco (1 a 4) - logo $r_{\max} + 1 = 4 + 1 = 5$. Dividir por $r_{\max} + 1$ normaliza o fator de risco para no máximo $1$, valor atingido exatamente quando $r_c = r_{\max}$. O $+1$ no numerador evita que o risco mínimo zere o fator: com $r_c = 1$ ele vale $2/5 = 0.4$, e não $0$. Assim o risco máximo ($5/5 = 1.0$) vale $2.5\times$ o risco mínimo ($0.4$).
+
+**2. Contribuição de cada critério** pondera a gravidade pelo peso clínico:
+
+$$\text{contrib}_c \;=\; w_c \times g_c$$
+
+Se um mesmo critério dispara várias vezes para a mesma pessoa, mantém-se apenas a contribuição mais alta.
+
+**3. Agregação por pessoa** resume todos os critérios ativos em dois termos:
+
+$$\text{termo}_{\max} = \max_c \left(w_c \cdot g_c\right) \qquad \text{termo}_{\text{soma}} = \sum_c \left(w_c \cdot g_c\right)$$
+
+O $\text{termo}_{\max}$ é a pendência mais grave (domina o score); o $\text{termo}_{\text{soma}}$ é a carga total de pendências.
+
+**4. Score total** combina os dois termos, com o multiplicador de gestante sobre a pendência mais grave e o peso de carga total sobre a soma:
+
+$$\text{gravidade\_total} \;=\; \text{termo}_{\max} \cdot \left(1 + \alpha \cdot \mathbf{1}_{\text{gestante}}\right) \;+\; \lambda \cdot \text{termo}_{\text{soma}}$$
+
+onde $\alpha = 1.0$ é o **multiplicador de gestante**, $\lambda = 0.5$ é o **peso de carga total** e $\mathbf{1}_{\text{gestante}}$ vale $1$ se a pessoa é gestante e $0$ caso contrário (ou seja, gestante dobra o $\text{termo}_{\max}$).
+
+**5. Reescala para 0-100** (apenas para apresentação na fila):
+
+$$\text{score}_{0\text{-}100} \;=\; 100 \times \min\left(\frac{\text{gravidade\_total}}{\text{teto}},\ 1\right)$$
+
+onde o $\text{teto}$ é o percentil 95 da distribuição de $\text{gravidade\_total}$ daquele dia, recalculado a cada atualização, de modo que cerca de 5% das pessoas saturam em 100.
+
+### Outros parâmetros do score
+
+Os três parâmetros abaixo são exatamente os que aparecem na fórmula acima.
+
+| Parâmetro                | Símbolo na fórmula | Valor             | O que faz |
+|--------------------------|:------------------:|-------------------|-----------|
+| Peso de carga total      | $\lambda$          | 0.5               | Controla o quanto "ter várias pendências ao mesmo tempo" ($\text{termo}_{\text{soma}}$) pesa no score. |
+| Multiplicador de gestante| $\alpha$           | 1.0               | Dobra a contribuição da pendência mais grave ($\text{termo}_{\max}$) quando a pessoa está gestante. |
+| Amortecimento de risco   | $\dfrac{r_c + 1}{r_{\max} + 1}$ | (risco + 1) / 5 | Normaliza o risco pelo seu valor máximo: o denominador é $r_{\max} + 1 = 4 + 1 = 5$, onde $r_{\max} = 4$ é o maior valor da escala (não é um 5 arbitrário). Suaviza a diferença entre risco baixo e alto, fazendo o risco máximo (4) valer 2.5 vezes o risco mínimo (1). |
 
 ## 13. Equipe
 
@@ -314,7 +365,7 @@ Este projeto é desenvolvido pelo **Núcleo de Tecnologia da Informação (NTI)*
 ### Equipe Desenvolvedora (NTI)
 - Juliana Paranhos - Coordenadora de TI
 - Matheus Miloski - Engenheiro de Dados
-- Marcos Paulo - Programador Front-End
+- Marcos Chagas - Programador Front-End
 - Eduardo Ataíde - Programador Back-End
 
 ### Equipe de Saúde (SUBGERAL)

--- a/models/marts/subgeral/monitora_cancer/SOBRE.md
+++ b/models/marts/subgeral/monitora_cancer/SOBRE.md
@@ -296,7 +296,22 @@ Estas três pendências descrevem a mesma situação em níveis de urgência cre
 | Prazo para início de tratamento próximo do limite legal  | Pessoa diagnosticada há 45 dias ou mais e ainda sem solicitação SER. |
 | Prazo legal para início de tratamento ultrapassado       | Pessoa diagnosticada há 60 dias ou mais e ainda sem solicitação SER (prazo legal de 60 dias ultrapassado). |
 
-## 12. Atualização de Dados
+## 12. A Linha do Tempo da Pessoa
+
+Além da posição na fila (o score de gravidade), o sistema monta, para cada pessoa, uma ficha que a equipe usa no contato. Ela reúne:
+
+- **Identificação e contato**: nome, idade, raça/cor, telefone da pessoa e os telefones da clínica da família e da equipe responsável.
+- **Situação atual**: o status (SUSPEITA, DIAGNÓSTICO ou UNACON, veja a Seção 4) e o score de gravidade (Seção 9).
+- **Histórico de eventos**: todos os exames, consultas e encaminhamentos, do mais antigo ao mais recente. Cada evento traz o procedimento, as datas (pedido, autorização, realização e resultado), as unidades envolvidas, o resultado e o nível de risco informado pelo sistema de origem (por exemplo, a categoria BI-RADS no SISCAN ou a prioridade no SER). Aparece também um aviso quando a etapa está demorando mais do que o esperado (prazos na Seção 8).
+- **Pendências em aberto** (Seção 11).
+- **Tempos da linha de cuidado**, medidos no episódio atual (a sequência mais recente de eventos, com intervalos de até 180 dias - Seção 8.2):
+  - **Tempo total** (`tempo_total`): dias do início do episódio até a entrada na UNACON; se a pessoa ainda não chegou, conta até hoje.
+  - **Tempo até o diagnóstico** (`tempo_diagnostico`): dias do início do episódio até a pessoa passar a DIAGNÓSTICO ou UNACON.
+  - **Tempo diagnosticada sem tratamento** (`tempo_diagnostico_sem_tratamento`): dias entre o diagnóstico e o encaminhamento ao SER, acompanhando o prazo legal de 60 dias (Seção 8.2).
+
+Assim, em uma única tela, a equipe vê quem é a pessoa, em que ponto da linha de cuidado ela está e o que falta fazer.
+
+## 13. Atualização de Dados
 
 - **Frequência**: o sistema é atualizado **uma vez por dia**, de forma automática.
 - **O que é recalculado**: a lista de pessoas em monitoramento, o status de cada uma, as pendências em aberto e o score de gravidade.
@@ -358,7 +373,7 @@ Os três parâmetros abaixo são exatamente os que aparecem na fórmula acima.
 | Multiplicador de gestante| $\alpha$           | 1.0               | Dobra a contribuição da pendência mais grave ($\text{termo}_{\max}$) quando a pessoa está gestante. |
 | Amortecimento de risco   | $\dfrac{r_c + 1}{r_{\max} + 1}$ | (risco + 1) / 5 | Normaliza o risco pelo seu valor máximo: o denominador é $r_{\max} + 1 = 4 + 1 = 5$, onde $r_{\max} = 4$ é o maior valor da escala (não é um 5 arbitrário). Suaviza a diferença entre risco baixo e alto, fazendo o risco máximo (4) valer 2.5 vezes o risco mínimo (1). |
 
-## 13. Equipe
+## 14. Equipe
 
 Este projeto é desenvolvido pelo **Núcleo de Tecnologia da Informação (NTI)**, na Central de Regulação da **Subsecretaria Geral (SUBGERAL)** da Secretaria Municipal de Saúde do Rio de Janeiro (SMS Rio).
 

--- a/models/marts/subgeral/monitora_cancer/SOBRE.md
+++ b/models/marts/subgeral/monitora_cancer/SOBRE.md
@@ -353,15 +353,15 @@ O $\text{termo}_{\max}$ é a pendência mais grave (domina o score); o $\text{te
 
 **4. Score total** combina os dois termos, com o multiplicador de gestante sobre a pendência mais grave e o peso de carga total sobre a soma:
 
-$$\text{gravidade\_total} \;=\; \text{termo}_{\max} \cdot \left(1 + \alpha \cdot \mathbf{1}_{\text{gestante}}\right) \;+\; \lambda \cdot \text{termo}_{\text{soma}}$$
+$$\text{gravidade}_{\text{total}} \;=\; \text{termo}_{\max} \cdot \left(1 + \alpha \cdot \mathbf{1}_{\text{gestante}}\right) \;+\; \lambda \cdot \text{termo}_{\text{soma}}$$
 
 onde $\alpha = 1.0$ é o **multiplicador de gestante**, $\lambda = 0.5$ é o **peso de carga total** e $\mathbf{1}_{\text{gestante}}$ vale $1$ se a pessoa é gestante e $0$ caso contrário (ou seja, gestante dobra o $\text{termo}_{\max}$).
 
 **5. Reescala para 0-100** (apenas para apresentação na fila):
 
-$$\text{score}_{0\text{-}100} \;=\; 100 \times \min\left(\frac{\text{gravidade\_total}}{\text{teto}},\ 1\right)$$
+$$\text{score}_{0\text{-}100} \;=\; 100 \times \min\left(\frac{\text{gravidade}_{\text{total}}}{\text{teto}},\ 1\right)$$
 
-onde o $\text{teto}$ é o percentil 95 da distribuição de $\text{gravidade\_total}$ daquele dia, recalculado a cada atualização, de modo que cerca de 5% das pessoas saturam em 100.
+onde o $\text{teto}$ é o percentil 95 da distribuição de $\text{gravidade}_{\text{total}}$ daquele dia, recalculado a cada atualização, de modo que cerca de 5% das pessoas saturam em 100.
 
 ### Outros parâmetros do score
 

--- a/models/marts/subgeral/monitora_cancer/SOBRE.md
+++ b/models/marts/subgeral/monitora_cancer/SOBRE.md
@@ -30,7 +30,7 @@ flowchart LR
 
 As equipes da SMS Rio não conseguem entrar em contato com todas as pessoas em monitoramento no mesmo dia. É preciso uma ferramenta para apoiar as decisões neste processo.
 
-O objetivo do Monitora Câncer é, portando, responder, todos os dias, a duas perguntas:
+O objetivo do Monitora Câncer é, portanto, responder, todos os dias, a duas perguntas:
 
 1. **Quais pessoas estão em monitoramento agora?**
 2. **Em qual ordem a equipe deve contatá-las?**

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -201,9 +201,11 @@ models:
       identificação, contato, vínculo com a APS e um array ordenado de eventos
       (solicitações, autorizações, execuções e resultados). Inclui também
       indicadores derivados: status da paciente, gravidade_score (score
-      0-100 da fila de urgência, vindo de mart_monitora_cancer__gravidade)
-      e tempo total (dias até a UNACON para pacientes com SER, ou dias
-      desde o início da última sequência de eventos para pacientes sem SER).
+      0-100 da fila de urgência, vindo de mart_monitora_cancer__gravidade),
+      tempo total (dias até a UNACON para pacientes com SER, ou dias
+      desde o início da última sequência de eventos para pacientes sem SER)
+      e os tempos da linha de cuidado medidos no run atual (tempo_diagnostico
+      e tempo_diagnostico_sem_tratamento).
       Granularidade: 1 linha por paciente (cpf_particao).
     meta:
       owner: "SMS/SUBGERAL/CR/NTI"
@@ -280,6 +282,30 @@ models:
           feito até o dia atual. A data do início do percurso é a data de
           solicitação do primeiro evento em uma sequência de eventos com
           intervalo entre eles menor ou igual a 180 dias.
+
+      - name: tempo_diagnostico
+        description: >
+          Tempo, em dias, do início do run atual (último episódio, gaps <= 180
+          dias) até a paciente passar a DIAGNOSTICO ou UNACON — 1º evento do run
+          com diagnóstico confirmado (criterio_diagnostico) ou entrada no SER.
+          Preenchido só para quem atinge esse status no run atual; NULL em
+          SUSPEITA. Calculado em int_monitora_cancer__eventos_episodios.
+        data_tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              name: mart_monitora_cancer__pacientes_linha_tempo__tempo_diagnostico__accepted_range
+
+      - name: tempo_diagnostico_sem_tratamento
+        description: >
+          Tempo, em dias, no run atual, entre o diagnóstico confirmado
+          (criterio_diagnostico) e a 1ª solicitação SER — proxy do tempo
+          diagnosticada sem encaminhamento para tratamento. Preenchido só para
+          UNACON com diagnóstico em/antes do SER; NULL nos demais casos.
+          Calculado em int_monitora_cancer__eventos_episodios.
+        data_tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              name: mart_monitora_cancer__pacientes_linha_tempo__tempo_diagnostico_sem_tratamento__accepted_range
 
       - name: gestante
         description: >

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -99,6 +99,11 @@ select
 
     any_value (ev.tempo_total) as tempo_total,
 
+    -- tempos da linha de cuidado, medidos dentro do run atual (calculados em
+    -- int_monitora_cancer__eventos_episodios; NULL fora do escopo de cada um)
+    any_value (ev.tempo_diagnostico) as tempo_diagnostico,
+    any_value (ev.tempo_diagnostico_sem_tratamento) as tempo_diagnostico_sem_tratamento,
+
     -- pendências atuais (1 array por paciente, calculado em int_monitora_cancer__pendencias)
     any_value (pend.pendencia_atual) as pendencia_atual
 


### PR DESCRIPTION
Adds two per-patient timing metrics to the monitora_cancer linha do tempo, both measured within the **current care episode** (run). Updates docs after talking with stakeholders.