### PR TITLE
[monitora cancer] feat: scope monitora_cancer status to current journey

### DIFF
--- a/models/intermediate/subgeral/monitora_cancer/README.md
+++ b/models/intermediate/subgeral/monitora_cancer/README.md
@@ -83,7 +83,7 @@ Grupos funcionais dos modelos intermediários:
 - **eventos** — `eventos_episodios` (compute compartilhado por paciente,
   com `run_id`) e `pendencias`.
 - **gravidade** (`gravidade_indicador/`) — `eventos_run_atual` (fonte
-  ephemeral compartilhada do run atual), 7 modelos de critério em
+  ephemeral compartilhada da jornada atual), 7 modelos de critério em
   `criterios/`, `gravidade_instancias` (agregador) e `gravidade`
   (orquestrador do score). README dedicado em
   [`gravidade_indicador/README.md`](gravidade_indicador/README.md).
@@ -92,18 +92,18 @@ Grupos funcionais dos modelos intermediários:
 
 - **Evento** — uma linha em `mart__fatos`. Granularidade
   `(sistema_origem, id_sistema_origem)`. Vem de SISREG, SER ou SISCAN.
-- **Episódio / run** — sequência consecutiva de eventos da mesma paciente
-  cujos gaps de `data_referencia_evento` são **≤ 180 dias**
+- **Jornada / episódio (run)** — sequência consecutiva de eventos da mesma
+  paciente cujos gaps de `data_referencia_evento` são **≤ 180 dias**
   (`episodio_gap_dias`). O `run_id` incrementa a cada gap maior que isso.
-  O score e a linha do tempo consideram **apenas o run atual** (último
-  episódio de cuidado).
-- **Status da paciente** — calculado sobre os eventos que qualificaram a
-  paciente para o monitoramento (`data_solicitacao >= 2025-01-01` E com
-  `criterio_suspeita` ou `criterio_diagnostico`): `UNACON` quando há ≥1
-  evento SER (entrada na regulação para oncologia); `DIAGNOSTICO` quando
-  há evento com critério de diagnóstico confirmado; `SUSPEITA` nos
-  demais casos da população-alvo.
-- **Score de gravidade** — número que ordena as pacientes do run atual por
+  O score e a linha do tempo consideram **apenas a jornada atual** (a
+  sequência de eventos mais recente).
+- **Status da paciente** — calculado **apenas sobre os eventos da jornada
+  atual** (eventos de jornadas antigas não contam), em
+  `int_monitora_cancer__eventos_episodios`: `UNACON` quando há ≥1 evento SER
+  na jornada atual (entrada na regulação para oncologia); `DIAGNOSTICO`
+  quando há evento com critério de diagnóstico confirmado na jornada atual;
+  `SUSPEITA` nos demais casos da população-alvo.
+- **Score de gravidade** — número que ordena as pacientes da jornada atual por
   **urgência de contato**: combina, por critério ativo, atraso × risco ×
   peso clínico, agrega por paciente (maior contribuição + soma das
   contribuições) e aplica multiplicador de gestante. A fila ordena por
@@ -125,7 +125,7 @@ Grupos funcionais dos modelos intermediários:
   um **contrato downstream estável** (nome/alias/schema), isolando o mart
   da reorganização interna da camada intermediária.
 - **`episodio_gap_dias = 180`** — eventos separados por mais de ~6 meses
-  são tratados como episódios de cuidado distintos.
+  são tratados como jornadas de cuidado distintas.
 
 ## Como adicionar uma nova fonte de dados
 
@@ -165,13 +165,13 @@ Termos de domínio do projeto. Os termos **específicos do score**
 | **evento** | Linha em `mart__fatos`. Granularidade `(sistema_origem, id_sistema_origem)`. SISREG, SER ou SISCAN. |
 | **população-alvo** | Universo inicial de pacientes do monitoramento (`int_monitora_cancer__populacao_alvo`). |
 | **exclusões** | Regras que removem pacientes da população-alvo (`int_monitora_cancer__exclusoes`). |
-| **episódio / run** | Sequência consecutiva de eventos da paciente com gaps de `data_referencia_evento` ≤ 180 dias. |
-| **run_id / jornada_id** | Identificador do episódio; incrementa a cada gap > `episodio_gap_dias` (180) dentro do mesmo paciente. |
+| **jornada / episódio (run)** | Sequência consecutiva de eventos da paciente com gaps de `data_referencia_evento` ≤ 180 dias. A mais recente é a **jornada atual**. |
+| **run_id / jornada_id** | Identificador da jornada; incrementa a cada gap > `episodio_gap_dias` (180) dentro do mesmo paciente. |
 | **data_referencia_evento** | `MAX` das datas conhecidas do evento (solicitação, autorização, execução, resultado). |
 | **critério** | Motivo registrado para a paciente precisar de atenção (par gatilho/desfecho-esperado). Uma paciente pode ter vários ativos. |
 | **pendência** | Tarefa clínica esperando ser feita (ex.: biópsia pedida mas não realizada). Materializada em `int_monitora_cancer__pendencias`. |
-| **UNACON** | Unidade de Alta Complexidade em Oncologia. Status atribuído quando há ≥1 evento SER. |
-| **DIAGNOSTICO** | Status quando há evento com `criterio_diagnostico = TRUE`. |
+| **UNACON** | Unidade de Alta Complexidade em Oncologia. Status atribuído quando há ≥1 evento SER na jornada atual. |
+| **DIAGNOSTICO** | Status quando há evento com `criterio_diagnostico = TRUE` na jornada atual. |
 | **SUSPEITA** | Status default da população-alvo (sem UNACON nem DIAGNOSTICO). |
 | **BI-RADS** | Classificação radiológica de mamografia (Categoria 0..6). Mapeada para `risco` na fonte SISCAN. |
 | **criterio_suspeita / criterio_diagnostico** | Flags que classificam o evento como suspeita ou diagnóstico (de `parametros_*` para SISREG/SER; de regras de laudo para SISCAN). |

--- a/models/intermediate/subgeral/monitora_cancer/_monitora_cancer__overview.md
+++ b/models/intermediate/subgeral/monitora_cancer/_monitora_cancer__overview.md
@@ -9,28 +9,30 @@ paciente. Atualização diária. Visão geral, DAG e glossário de projeto em
 
 
 {% docs monitora_cancer__episodio_run %}
-Episódio (ou "run"): sequência consecutiva de eventos da mesma paciente
-cujos gaps de `data_referencia_evento` são ≤ 180 dias
-(`episodio_gap_dias`). O `run_id` incrementa a cada gap maior que isso
-dentro do mesmo paciente. O score de gravidade e a linha do tempo
-consideram apenas o **run atual** (último episódio de cuidado).
+Jornada (ou episódio de cuidado, internamente "run"): sequência
+consecutiva de eventos da mesma paciente cujos gaps de
+`data_referencia_evento` são ≤ 180 dias (`episodio_gap_dias`). O `run_id`
+incrementa a cada gap maior que isso dentro do mesmo paciente. O score de
+gravidade e a linha do tempo consideram apenas a **jornada atual** (a
+sequência de eventos mais recente).
 {% enddocs %}
 
 
 {% docs monitora_cancer__status %}
-Classificação da paciente no monitoramento, calculada sobre os eventos
-que a qualificaram (data_solicitacao >= 2025-01-01 com criterio_suspeita
-ou criterio_diagnostico): "UNACON" quando há pelo menos um evento vindo
-do SER (regulação para oncologia); "DIAGNOSTICO" quando há evento com
-critério de diagnóstico confirmado; "SUSPEITA" nos demais casos da
-população-alvo.
+Classificação da paciente no monitoramento, calculada APENAS sobre os
+eventos da jornada atual (run_id = max(run_id) em
+int_monitora_cancer__eventos_episodios) — eventos de jornadas antigas não
+influenciam o status: "UNACON" quando há pelo menos um evento vindo do SER
+(regulação para oncologia) na jornada atual; "DIAGNOSTICO" quando há evento
+com critério de diagnóstico confirmado na jornada atual; "SUSPEITA" nos
+demais casos da população-alvo.
 {% enddocs %}
 
 
 {% docs monitora_cancer__gravidade_score %}
 Apresentação 0-100 do score de gravidade da paciente. Reflete
 `mart_monitora_cancer__gravidade.gravidade_total_0_100`, com clip no p95
-dinâmico de `gravidade_total` do run atual — acima do teto, satura em 100.
+dinâmico de `gravidade_total` da jornada atual — acima do teto, satura em 100.
 A ordenação canônica da fila continua via `gravidade_total` bruto (em
 `mart_monitora_cancer__gravidade`), não esta coluna. Pacientes sem critério
 ativo recebem 0 — inclusive gestantes (o multiplicador atua sobre o

--- a/models/intermediate/subgeral/monitora_cancer/eventos/README.md
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/README.md
@@ -4,5 +4,5 @@ Compute compartilhado por paciente.
 
 | Modelo | Papel |
 |---|---|
-| `int_monitora_cancer__eventos_episodios` | Tabela compartilhada por `mart__gravidade` e `mart__pacientes_linha_tempo` (materializada para evitar trabalho duplo). Calcula o `run_id` (episódio de cuidado, gap ≤ 180 dias) e os tempos por paciente broadcast em cada linha: `tempo_total` e, no run atual, `tempo_diagnostico` e `tempo_diagnostico_sem_tratamento`. |
+| `int_monitora_cancer__eventos_episodios` | Tabela compartilhada por `mart__gravidade` e `mart__pacientes_linha_tempo` (materializada para evitar trabalho duplo). Calcula o `run_id` (jornada de cuidado, gap ≤ 180 dias), o `status` (derivado da jornada atual) e os tempos por paciente broadcast em cada linha: `tempo_total` e, na jornada atual, `tempo_diagnostico` e `tempo_diagnostico_sem_tratamento`. |
 | `int_monitora_cancer__pendencias` | Deriva rótulos de pendência por paciente a partir de `eventos_episodios`. |

--- a/models/intermediate/subgeral/monitora_cancer/eventos/_eventos__schema.yml
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/_eventos__schema.yml
@@ -4,22 +4,26 @@ models:
   - name: int_monitora_cancer__eventos_episodios
     description: >
       Eventos da população-alvo em forma longa, com janelas temporais
-      (dias_proximo_evento), identificador de episódio de cuidado (run_id)
-      e agregados de tempo da jornada (tempo_total, tempo_diagnostico,
+      (dias_proximo_evento), identificador de jornada de cuidado (run_id)
+      e agregados por paciente (status, tempo_total, tempo_diagnostico,
       tempo_diagnostico_sem_tratamento) broadcasted em cada linha.
 
-      Episódios ("runs"): sequências consecutivas de eventos da mesma
-      paciente cujos gaps entre data_referencia_evento não excedem
+      Jornadas (internamente "runs"): sequências consecutivas de eventos da
+      mesma paciente cujos gaps entre data_referencia_evento não excedem
       episodio_gap_dias (default 180 dias, var() do dbt). O run_id
       incrementa a cada gap > episodio_gap_dias dentro do mesmo paciente.
 
-      tempo_total: para pacientes com SER, dias do início da run que
+      status: derivado APENAS dos eventos da jornada atual (run_id =
+      max(run_id)) — eventos de jornadas antigas não classificam mais a
+      paciente; ver o doc da coluna status.
+
+      tempo_total: para pacientes com SER, dias do início da jornada que
       contém o primeiro SER até a data desse primeiro SER (proxy do tempo
       decorrido até a entrada em UNACON); para pacientes sem SER, dias
-      do início da última run até a data atual.
+      do início da última jornada até a data atual.
 
-      tempo_diagnostico e tempo_diagnostico_sem_tratamento: tempos da jornada
-      medidos no run atual (run_id = max(run_id)); ver a descrição de cada coluna.
+      tempo_diagnostico e tempo_diagnostico_sem_tratamento: tempos medidos
+      na jornada atual (run_id = max(run_id)); ver a descrição de cada coluna.
 
       Granularidade: 1 linha por evento (mesma de mart_monitora_cancer__fatos
       restrita à população-alvo, via LEFT JOIN de pop em fatos por
@@ -80,6 +84,12 @@ models:
       - name: status
         description: '{{ doc("monitora_cancer__status") }}'
         data_type: string
+        data_tests:
+          - not_null:
+              name: int_monitora_cancer__eventos_episodios__status__not_null
+          - accepted_values:
+              values: ['UNACON', 'DIAGNOSTICO', 'SUSPEITA']
+              name: int_monitora_cancer__eventos_episodios__status__accepted_values
 
       - name: telefone
         description: Telefone pessoal da paciente (bcadastro ou fallback em telefones_validos).
@@ -234,10 +244,10 @@ models:
 
       - name: run_id
         description: >
-          Identificador do episódio de cuidado, incrementa a cada gap >
+          Identificador da jornada de cuidado, incrementa a cada gap >
           episodio_gap_dias (default 180) entre data_referencia_evento
           dentro da mesma paciente. Reseta por paciente; o maior run_id
-          de cada paciente é o "run atual" usado pela cadeia de gravidade
+          de cada paciente é a "jornada atual" usada pela cadeia de gravidade
           (int_monitora_cancer__eventos_run_atual).
         data_type: int64
         data_tests:
@@ -246,23 +256,23 @@ models:
 
       - name: tempo_total
         description: >
-          Para pacientes com SER, dias do início da run que contém o
+          Para pacientes com SER, dias do início da jornada que contém o
           primeiro SER até a data desse primeiro SER. Para pacientes sem
-          SER, dias do início da última run até hoje. NULL quando o
+          SER, dias do início da última jornada até hoje. NULL quando o
           cálculo resulta em 0 (mesmo dia). Broadcasted: mesmo valor em
           todas as linhas de uma paciente.
         data_type: int64
 
       - name: tempo_diagnostico
         description: >
-          Dias, no run atual, do início do run (data_solicitacao mais antiga)
-          até o 1º evento que vira DIAGNOSTICO/UNACON (criterio_diagnostico OU
-          fonte = 'SER'). >= 0 por construção; NULL em SUSPEITA. Broadcasted.
+          Dias, na jornada atual, do início da jornada (data_solicitacao mais
+          antiga) até o 1º evento que vira DIAGNOSTICO/UNACON (criterio_diagnostico
+          OU fonte = 'SER'). >= 0 por construção; NULL em SUSPEITA. Broadcasted.
         data_type: int64
 
       - name: tempo_diagnostico_sem_tratamento
         description: >
-          Dias, no run atual, do 1º diagnóstico confirmado (criterio_diagnostico)
+          Dias, na jornada atual, do 1º diagnóstico confirmado (criterio_diagnostico)
           até a 1ª solicitação SER. NULL quando não há diagnóstico em/antes do
           SER — só assume valor para UNACON. Broadcasted.
         data_type: int64

--- a/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__eventos_episodios.sql
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__eventos_episodios.sql
@@ -1,22 +1,27 @@
 -- noqa: disable=LT08
 
 -- Eventos de monitoramento de câncer de mama em forma longa, com janelas
--- temporais (dias_proximo_evento), identificador de episódio (run_id) e
--- agregados por paciente (tempo_total, tempo_diagnostico,
+-- temporais (dias_proximo_evento), identificador de jornada (run_id) e
+-- agregados por paciente (status, tempo_total, tempo_diagnostico,
 -- tempo_diagnostico_sem_tratamento) broadcast em cada linha.
 --
--- Episódios ("runs"): sequências consecutivas de eventos cujos gaps entre
--- data_referencia_evento não excedem `episodio_gap_dias` (default 180 dias).
+-- Jornadas (internamente "runs"): sequências consecutivas de eventos cujos gaps
+-- entre data_referencia_evento não excedem `episodio_gap_dias` (default 180 dias).
 -- O run_id incrementa a cada gap > episodio_gap_dias dentro do mesmo paciente.
 --
--- tempo_total:
---   - pacientes com SER: dias do início da run que contém o primeiro SER até
---     a data desse primeiro SER;
---   - pacientes sem SER: dias do início da última run até a data atual.
+-- status (UNACON / DIAGNOSTICO / SUSPEITA): derivado APENAS dos eventos da
+-- jornada atual (run_id = max(run_id)), pela regra de prioridade SER >
+-- diagnóstico confirmado > suspeita. Antes era calculado em populacao_alvo sobre
+-- todo o histórico; agora reflete só a jornada atual.
 --
--- tempo_diagnostico / tempo_diagnostico_sem_tratamento: medidos no run atual
+-- tempo_total:
+--   - pacientes com SER: dias do início da jornada que contém o primeiro SER até
+--     a data desse primeiro SER;
+--   - pacientes sem SER: dias do início da última jornada até a data atual.
+--
+-- tempo_diagnostico / tempo_diagnostico_sem_tratamento: medidos na jornada atual
 -- (run_id = max(run_id), como int_monitora_cancer__eventos_run_atual):
---   - tempo_diagnostico: dias do início do run atual até o 1º evento que vira
+--   - tempo_diagnostico: dias do início da jornada atual até o 1º evento que vira
 --     DIAGNOSTICO/UNACON (criterio_diagnostico OU fonte = 'SER'). NULL em SUSPEITA.
 --   - tempo_diagnostico_sem_tratamento: dias do 1º diagnóstico confirmado
 --     (criterio_diagnostico) até a 1ª solicitação SER. NULL sem diagnóstico
@@ -60,7 +65,6 @@ with
             pop.clinica_sf_ap as ap,
             pop.clinica_sf as cf,
             pop.equipe_sf,
-            pop.status,
             pop.telefone,
             pop.clinica_sf_telefone as telefone_cf,
             pop.equipe_sf_telefone as telefone_esf,
@@ -155,10 +159,10 @@ with
             )
     ),
 
-    -- "Início" da run = data de solicitação do primeiro evento da sequência.
-    -- A sequência (run) é definida pelas fronteiras em data_referencia_evento
-    -- (gaps > episodio_gap_dias quebram a run); aqui usamos a data_solicitacao
-    -- mais antiga dentro da run como marcador de quando a paciente entrou
+    -- "Início" da jornada = data de solicitação do primeiro evento da sequência.
+    -- A sequência (jornada) é definida pelas fronteiras em data_referencia_evento
+    -- (gaps > episodio_gap_dias quebram a jornada); aqui usamos a data_solicitacao
+    -- mais antiga dentro da jornada como marcador de quando a paciente entrou
     -- naquele percurso de cuidado.
     run_starts as (
         select
@@ -231,7 +235,7 @@ with
             and psi.primeira_ser_run_id = rs_ser.run_id
     ),
 
-    -- Run atual (run_id = max(run_id)). Replica int_monitora_cancer__eventos_run_atual
+    -- Jornada atual (run_id = max(run_id)). Replica int_monitora_cancer__eventos_run_atual
     -- (downstream deste — evita ciclo). Base dos tempos de diagnóstico abaixo.
     eventos_run_atual as (
         select *
@@ -239,7 +243,22 @@ with
         qualify run_id = max(run_id) over (partition by cpf_particao)
     ),
 
-    -- Início do run atual: data_solicitacao mais antiga (mesmo marcador de run_starts).
+    -- Status da paciente derivado APENAS dos eventos da jornada atual (mesma regra
+    -- de prioridade de antes: SER > diagnóstico confirmado > suspeita). Assim
+    -- um SER/diagnóstico de uma jornada antiga não classifica mais a paciente.
+    status_por_paciente as (
+        select
+            cpf_particao,
+            case
+                when max(case when fonte = 'SER' then 1 else 0 end) = 1 then 'UNACON'
+                when max(cast(criterio_diagnostico as int64)) = 1 then 'DIAGNOSTICO'
+                else 'SUSPEITA'
+            end as status
+        from eventos_run_atual
+        group by cpf_particao
+    ),
+
+    -- Início da jornada atual: data_solicitacao mais antiga (mesmo marcador de run_starts).
     run_atual_start as (
         select
             cpf_particao,
@@ -248,7 +267,7 @@ with
         group by cpf_particao
     ),
 
-    -- 1º evento do run atual que vira DIAGNOSTICO/UNACON (criterio_diagnostico OU SER).
+    -- 1º evento da jornada atual que vira DIAGNOSTICO/UNACON (criterio_diagnostico OU SER).
     marco_diagnostico_run_atual as (
         select
             cpf_particao,
@@ -267,7 +286,7 @@ with
             )
     ),
 
-    -- 1º diagnóstico confirmado do run atual (criterio_diagnostico).
+    -- 1º diagnóstico confirmado da jornada atual (criterio_diagnostico).
     diagnostico_run_atual as (
         select
             cpf_particao,
@@ -286,7 +305,7 @@ with
             )
     ),
 
-    -- 1ª solicitação SER do run atual.
+    -- 1ª solicitação SER da jornada atual.
     ser_run_atual as (
         select
             cpf_particao,
@@ -306,11 +325,11 @@ with
     ),
 
     -- Broadcast por paciente. Dirigida por marco_diagnostico_run_atual: quem não
-    -- tem marco no run atual (SUSPEITA) não entra e fica NULL via LEFT JOIN final.
+    -- tem marco na jornada atual (SUSPEITA) não entra e fica NULL via LEFT JOIN final.
     tempos_diagnostico_por_paciente as (
         select
             mdr.cpf_particao,
-            -- (i) >= 0 por construção (o marco está no run que começa no min da solicitação)
+            -- (i) >= 0 por construção (o marco está na jornada que começa no min da solicitação)
             date_diff(mdr.marco_data, ras.run_atual_start_data, day) as tempo_diagnostico,
             -- (ii) NULL quando não há diagnóstico em/antes do SER
             if(
@@ -336,7 +355,7 @@ select
     ev.ap,
     ev.cf,
     ev.equipe_sf,
-    ev.status,
+    spp.status,
     ev.telefone,
     ev.telefone_cf,
     ev.telefone_esf,
@@ -373,5 +392,6 @@ select
     tdp.tempo_diagnostico_sem_tratamento
 
 from eventos_com_run as ev
+    left join status_por_paciente as spp using (cpf_particao)
     left join tempo_total_por_paciente as ttp using (cpf_particao)
     left join tempos_diagnostico_por_paciente as tdp using (cpf_particao)

--- a/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__pendencias.sql
+++ b/models/intermediate/subgeral/monitora_cancer/eventos/int_monitora_cancer__pendencias.sql
@@ -40,7 +40,7 @@
 --     futuro (data_execucao > hoje), indicando que a paciente está
 --     aguardando a data agendada para execução.
 --   • tempo_total já é calculado em eventos_episodios: para pacientes sem
---     SER, equivale aos dias decorridos do início da última run até hoje —
+--     SER, equivale aos dias decorridos do início da última jornada até hoje —
 --     usado como proxy do tempo desde o ingresso no percurso de cuidado.
 --   • Os valores de evento_status para SER são preservados de raw_ser_metabase
 --     (coluna solicitacao_estado), que armazena 'CHEGADA_NAO_CONFIRMADA',

--- a/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/README.md
+++ b/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/README.md
@@ -171,7 +171,7 @@ Sistemas mencionados nos critérios:
 | Arquivo | Para que serve |
 |---|---|
 | `criterios/int_monitora_cancer__criterio_N_*.sql` (×7) | um arquivo por critério, ephemeral: define gatilho/desfecho (cross-evento) ou `source_filter` (intra-evento) e emite a relação canônica bruta de 8 colunas. Passo a passo em [`criterios/README.md`](criterios/README.md). |
-| `int_monitora_cancer__eventos_run_atual.sql` | ephemeral, fonte única compartilhada do run atual de cada paciente (com `data_expected` pré-calculada), consumida pelos 7 critérios e pela CTE de gestante. |
+| `int_monitora_cancer__eventos_run_atual.sql` | ephemeral, fonte única compartilhada da jornada atual de cada paciente (com `data_expected` pré-calculada), consumida pelos 7 critérios e pela CTE de gestante. |
 | `int_monitora_cancer__gravidade_instancias.sql` | agregador: `UNION ALL` dos 7 critérios, aplica `fator_tempo`/`fator_risco`/`gravidade_criterio`, JOIN de gestante e filtro `dias_atraso > 0` (1 linha por critério ativo). |
 | `int_monitora_cancer__gravidade.sql` | colapso MAX por critério, agregação por paciente (`termo_max` + `termo_soma`), multiplicador de gestante e reescala 0-100 com clip dinâmico no p95. |
 | `mart_monitora_cancer__gravidade.sql` | tabela final que alimenta a fila de contato (passthrough do intermediário). |

--- a/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/criterios/README.md
+++ b/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/criterios/README.md
@@ -2,7 +2,7 @@
 
 Um arquivo SQL por critério de gravidade. Cada arquivo é **ephemeral**, lê
 [`int_monitora_cancer__eventos_run_atual`](../int_monitora_cancer__eventos_run_atual.sql)
-(fonte compartilhada dos eventos do run atual), define as CTEs locais que
+(fonte compartilhada dos eventos da jornada atual), define as CTEs locais que
 precisar e termina retornando a **relação canônica bruta** de 8 colunas:
 
 ```

--- a/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__eventos_run_atual.sql
+++ b/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__eventos_run_atual.sql
@@ -1,4 +1,4 @@
--- Eventos do RUN ATUAL apenas (último episódio de cuidado de cada paciente),
+-- Eventos da JORNADA ATUAL apenas (a sequência de eventos mais recente de cada paciente),
 -- com a data_expected pré-calculada. Fonte única compartilhada pelos 7
 -- modelos de critério (gravidade_indicador/criterios/) e pelo agregador
 -- int_monitora_cancer__gravidade_instancias (CTE gestantes). Ephemeral: o

--- a/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__gravidade.sql
+++ b/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__gravidade.sql
@@ -24,7 +24,7 @@
 
 -- (Sem parâmetro teto_score_apresentacao.) O teto da reescala 0-100 é
 -- computado DINAMICAMENTE como o p95 da distribuição de gravidade_total
--- do run atual — ver CTE teto_apresentacao abaixo. Dispensa
+-- da jornada atual — ver CTE teto_apresentacao abaixo. Dispensa
 -- recalibração manual após mudança de pesos/parâmetros.
 
 -- Sem guard de invariante de ordem: gestante-sem-critério tem termo_max
@@ -158,9 +158,9 @@ with
         group by cpf_particao
     ),
 
-    -- Universo de pacientes do run atual (com OU sem critério ativo).
+    -- Universo de pacientes da jornada atual (com OU sem critério ativo).
     -- Seed do LEFT JOIN abaixo — única via pela qual gestantes-sem-critério
-    -- entram no mart. Fonte: eventos_run_atual (fonte única de "run atual +
+    -- entram no mart. Fonte: eventos_run_atual (fonte única de "jornada atual +
     -- gestante", mesma usada na CTE gestantes de gravidade_instancias), em vez
     -- de reaplicar aqui o filtro qualify run_id = max(run_id).
     universo_pacientes as (

--- a/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__gravidade_instancias.sql
+++ b/models/intermediate/subgeral/monitora_cancer/gravidade_indicador/int_monitora_cancer__gravidade_instancias.sql
@@ -22,7 +22,7 @@
 -- INSTÂNCIAS DE CRITÉRIO ATIVAS — AGREGADOR (granularidade fina)
 -- ════════════════════════════════════════════════════════════════════════════
 --
--- Uma linha por (cpf_particao, criterio, etapa, data_trigger) ativa no run
+-- Uma linha por (cpf_particao, criterio, etapa, data_trigger) ativa na jornada
 -- atual. "Ativa" = gatilho disparou AND desfecho esperado ainda não chegou
 -- AND dias_atraso > 0.
 --
@@ -36,7 +36,7 @@
 -- expondo fator_tempo, fator_risco, gravidade_criterio; (c) JOIN de gestante;
 -- (d) filtro de folga dias_atraso > 0.
 --
--- Os eventos do run atual (com data_expected) vêm de
+-- Os eventos da jornada atual (com data_expected) vêm de
 -- int_monitora_cancer__eventos_run_atual (ephemeral compartilhado pelos 7
 -- critérios e pela CTE gestantes abaixo — o dbt o injeta uma única vez).
 --

--- a/models/intermediate/subgeral/monitora_cancer/populacao/_populacao__schema.yml
+++ b/models/intermediate/subgeral/monitora_cancer/populacao/_populacao__schema.yml
@@ -31,16 +31,6 @@ models:
           - not_null:
               name: int_monitora_cancer__populacao_alvo__paciente_cpf__not_null
 
-      - name: status
-        description: '{{ doc("monitora_cancer__status") }}'
-        data_type: string
-        data_tests:
-          - not_null:
-              name: int_monitora_cancer__populacao_alvo__status__not_null
-          - accepted_values:
-              values: ['UNACON', 'DIAGNOSTICO', 'SUSPEITA']
-              name: int_monitora_cancer__populacao_alvo__status__accepted_values
-
       - name: nome
         description: Nome completo da paciente, obtido de raw_bcadastro__cpf.
         data_type: string

--- a/models/intermediate/subgeral/monitora_cancer/populacao/int_monitora_cancer__populacao_alvo.sql
+++ b/models/intermediate/subgeral/monitora_cancer/populacao/int_monitora_cancer__populacao_alvo.sql
@@ -16,14 +16,11 @@
 --       documentação completa de cada regra.
 
 with
+    -- Conjunto de CPFs qualificados para o monitoramento. O status da paciente
+    -- NÃO é decidido aqui: ele é derivado da jornada atual em
+    -- int_monitora_cancer__eventos_episodios (onde o run_id existe).
     populacao_interesse as (
-        select
-            paciente_cpf,
-            case
-                when max(case when sistema_origem = 'SER' then 1 else 0 end) = 1 then 'UNACON'
-                when max(cast(criterio_diagnostico as int64)) = 1 then 'DIAGNOSTICO'
-                else 'SUSPEITA'
-            end as status
+        select distinct paciente_cpf
         from {{ ref("mart_monitora_cancer__fatos") }}
         where
             data_solicitacao >= "2025-01-01"
@@ -31,7 +28,6 @@ with
                 criterio_suspeita = true
                 or criterio_diagnostico = true
             )
-        group by paciente_cpf
     ),
 
     gestantes_ativas as (
@@ -42,7 +38,6 @@ with
 
 select
     pop.paciente_cpf,
-    pop.status,
     bcadastro.nome,
 
     -- raça/cor escolhida pela regra de prioridade definida em pacientes_subgeral__dim_paciente:

--- a/models/marts/subgeral/monitora_cancer/SOBRE.md
+++ b/models/marts/subgeral/monitora_cancer/SOBRE.md
@@ -60,19 +60,19 @@ Uma pessoa entra na lista quando atende, ao mesmo tempo, a todos os critérios a
 
 ### Status da pessoa
 
-Quando uma pessoa entra, ela também recebe um **status**. O status diz em que ponto da linha de cuidado ela está:
+Quando uma pessoa entra, ela também recebe um **status**. O status diz em que ponto da linha de cuidado ela está. Ele é decidido olhando **apenas a jornada atual** (a sequência de eventos mais recente - ver a regra dos 180 dias mais adiante): eventos de jornadas antigas não contam para o status atual.
 
 - **SUSPEITA**: há indícios em exames ou pedidos de exames, mas o câncer ainda não foi confirmado.
 - **DIAGNÓSTICO**: o câncer foi confirmado por exame (por exemplo, mamografia BI-RADS categoria 6 ou biópsia com lesão neoplásica).
-- **UNACON**: a pessoa já foi encaminhada para uma unidade de alta complexidade oncológica - ou seja, tem pelo menos um evento registrado no SER.
+- **UNACON**: a pessoa já foi encaminhada para uma unidade de alta complexidade oncológica - ou seja, tem pelo menos uma solicitação de evento registrada no SER na jornada atual.
 
-A regra de decisão é a seguinte:
+A regra de decisão é a seguinte (sempre considerando só os eventos da jornada atual):
 
 ```mermaid
 flowchart TD
     A[Paciente na<br/>população-alvo]
-    Q1{Tem pelo<br/>menos um<br/>evento<br/>no SER?}
-    Q2{Algum exame<br/>com<br/>diagnóstico<br/>confirmado?}
+    Q1{Tem pelo<br/>menos uma<br/>solicitação no SER<br/>na jornada<br/>atual?}
+    Q2{Algum exame<br/>com diagnóstico<br/>confirmado na<br/>jornada atual?}
     R1[UNACON]
     R2[DIAGNÓSTICO]
     R3[SUSPEITA]
@@ -83,7 +83,7 @@ flowchart TD
     Q2 -- não --> R3
 ```
 
-**Exemplo:** Uma pessoa faz mamografia e o laudo sai como BI-RADS 4. Ela entra com status SUSPEITA. Em seguida, faz uma biópsia que confirma lesão neoplásica: passa para DIAGNÓSTICO. Quando o pedido de consulta com mastologista oncológico aparece no SER, passa para UNACON.
+**Exemplo:** Dentro de uma mesma jornada de cuidado, uma pessoa faz mamografia e o laudo sai como BI-RADS 4. Ela entra com status SUSPEITA. Em seguida, faz uma biópsia que confirma lesão neoplásica: passa para DIAGNÓSTICO. Quando o pedido de consulta com mastologista oncológico aparece no SER, passa para UNACON. Se mais tarde ela iniciar uma nova jornada (após mais de 180 dias sem eventos), o status volta a ser avaliado só pelos eventos dessa nova jornada.
 
 ## 5. Tabela de Procedimentos Monitorados
 
@@ -196,7 +196,7 @@ Para cada procedimento, o sistema espera que ele seja autorizado e executado den
 | Parâmetro                                  | Valor       | Para que serve |
 |--------------------------------------------|-------------|----------------|
 | Data de corte                              | 01/01/2025  | Eventos anteriores a essa data não contam para entrada da pessoa na lista. |
-| Episódio de cuidado                        | 180 dias    | Eventos da mesma pessoa separados por mais de 180 dias são tratados como episódios diferentes de cuidado. O sistema considera apenas o episódio mais recente. |
+| Jornada de cuidado                         | 180 dias    | Eventos da mesma pessoa separados por mais de 180 dias são tratados como jornadas de cuidado diferentes. O sistema considera apenas a jornada atual (a mais recente). |
 | Exclusão por SER antigo (status ALTA)      | 3 meses     | Se o último evento da pessoa foi um SER com status ALTA há 3 meses ou mais, a pessoa sai da lista. |
 | Exclusão por SER antigo (chegada/cancelada)| 6 meses     | Se o último evento foi um SER com status CHEGADA_CONFIRMADA ou CANCELADA há 6 meses ou mais, a pessoa sai da lista. |
 | Alerta de prazo legal próximo do limite    | 45 dias     | A partir de 45 dias desde o diagnóstico, o sistema avisa que o prazo legal para início de tratamento está próximo. |
@@ -304,9 +304,9 @@ Além da posição na fila (o score de gravidade), o sistema monta, para cada pe
 - **Situação atual**: o status (SUSPEITA, DIAGNÓSTICO ou UNACON, veja a Seção 4) e o score de gravidade (Seção 9).
 - **Histórico de eventos**: todos os exames, consultas e encaminhamentos, do mais antigo ao mais recente. Cada evento traz o procedimento, as datas (pedido, autorização, realização e resultado), as unidades envolvidas, o resultado e o nível de risco informado pelo sistema de origem (por exemplo, a categoria BI-RADS no SISCAN ou a prioridade no SER). Aparece também um aviso quando a etapa está demorando mais do que o esperado (prazos na Seção 8).
 - **Pendências em aberto** (Seção 11).
-- **Tempos da linha de cuidado**, medidos no episódio atual (a sequência mais recente de eventos, com intervalos de até 180 dias - Seção 8.2):
-  - **Tempo total** (`tempo_total`): dias do início do episódio até a entrada na UNACON; se a pessoa ainda não chegou, conta até hoje.
-  - **Tempo até o diagnóstico** (`tempo_diagnostico`): dias do início do episódio até a pessoa passar a DIAGNÓSTICO ou UNACON.
+- **Tempos da linha de cuidado**, medidos na jornada atual (a sequência mais recente de eventos, com intervalos de até 180 dias - Seção 8.2):
+  - **Tempo total** (`tempo_total`): dias do início da jornada até a entrada na UNACON; se a pessoa ainda não chegou, conta até hoje.
+  - **Tempo até o diagnóstico** (`tempo_diagnostico`): dias do início da jornada até a pessoa passar a DIAGNÓSTICO ou UNACON.
   - **Tempo diagnosticada sem tratamento** (`tempo_diagnostico_sem_tratamento`): dias entre o diagnóstico e o encaminhamento ao SER, acompanhando o prazo legal de 60 dias (Seção 8.2).
 
 Assim, em uma única tela, a equipe vê quem é a pessoa, em que ponto da linha de cuidado ela está e o que falta fazer.

--- a/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/_mart_monitora_cancer__schema.yml
@@ -204,7 +204,7 @@ models:
       0-100 da fila de urgência, vindo de mart_monitora_cancer__gravidade),
       tempo total (dias até a UNACON para pacientes com SER, ou dias
       desde o início da última sequência de eventos para pacientes sem SER)
-      e os tempos da linha de cuidado medidos no run atual (tempo_diagnostico
+      e os tempos da linha de cuidado medidos na jornada atual (tempo_diagnostico
       e tempo_diagnostico_sem_tratamento).
       Granularidade: 1 linha por paciente (cpf_particao).
     meta:
@@ -265,11 +265,13 @@ models:
       # ── qualificadores clínicos ───────────────────────────────────────────────
       - name: status
         description: >
-          Classificação da paciente no monitoramento, calculada sobre os eventos que
-          qualificaram a paciente para o monitoramento (data_solicitacao >= 2025-01-01
-          com criterio_suspeita ou criterio_diagnostico):
-          "UNACON" quando há pelo menos um evento vindo do SER (regulação para oncologia);
-          "DIAGNOSTICO" quando há evento com critério de diagnóstico confirmado;
+          Classificação da paciente no monitoramento, calculada APENAS sobre os
+          eventos da jornada atual (jornada_id = max, a sequência de eventos mais
+          recente) — eventos de jornadas antigas não influenciam o status:
+          "UNACON" quando há pelo menos um evento vindo do SER (regulação para oncologia)
+          na jornada atual;
+          "DIAGNOSTICO" quando há evento com critério de diagnóstico confirmado
+          na jornada atual;
           "SUSPEITA" nos demais casos da população-alvo.
 
       - name: gravidade_score
@@ -285,11 +287,11 @@ models:
 
       - name: tempo_diagnostico
         description: >
-          Tempo, em dias, do início do run atual (último episódio, gaps <= 180
-          dias) até a paciente passar a DIAGNOSTICO ou UNACON — 1º evento do run
-          com diagnóstico confirmado (criterio_diagnostico) ou entrada no SER.
-          Preenchido só para quem atinge esse status no run atual; NULL em
-          SUSPEITA. Calculado em int_monitora_cancer__eventos_episodios.
+          Tempo, em dias, do início da jornada atual (a sequência de eventos mais
+          recente, gaps <= 180 dias) até a paciente passar a DIAGNOSTICO ou UNACON
+          — 1º evento da jornada com diagnóstico confirmado (criterio_diagnostico)
+          ou entrada no SER. Preenchido só para quem atinge esse status na jornada
+          atual; NULL em SUSPEITA. Calculado em int_monitora_cancer__eventos_episodios.
         data_tests:
           - dbt_utils.accepted_range:
               min_value: 0
@@ -297,7 +299,7 @@ models:
 
       - name: tempo_diagnostico_sem_tratamento
         description: >
-          Tempo, em dias, no run atual, entre o diagnóstico confirmado
+          Tempo, em dias, na jornada atual, entre o diagnóstico confirmado
           (criterio_diagnostico) e a 1ª solicitação SER — proxy do tempo
           diagnosticada sem encaminhamento para tratamento. Preenchido só para
           UNACON com diagnóstico em/antes do SER; NULL nos demais casos.
@@ -360,10 +362,10 @@ models:
           resultado) em formato date e string, resultados dos exames das mamas,
           severidades de atraso, score de risco (float64) normalizado por sistema,
           o intervalo em dias até o próximo evento (dias_proximo_evento) e o
-          identificador do episódio (jornada_id) ao qual o evento pertence —
-          episódios são sequências consecutivas de eventos cujos gaps entre
-          data_referencia_evento não excedem 180 dias; o id incrementa a cada
-          gap maior, dentro de um mesmo paciente.
+          identificador da jornada de cuidado (jornada_id) ao qual o evento
+          pertence — jornadas são sequências consecutivas de eventos cujos gaps
+          entre data_referencia_evento não excedem 180 dias; o id incrementa a
+          cada gap maior, dentro de um mesmo paciente.
 
       - name: eventos.fonte
         description: Sistema de origem do evento (SISREG, SER ou SISCAN).
@@ -477,10 +479,10 @@ models:
 
       - name: eventos.jornada_id
         description: >
-          Identificador do episódio de cuidado (jornada) ao qual o evento
-          pertence. Episódios são sequências consecutivas de eventos da mesma
-          paciente cujo intervalo entre datas de referência não excede 180
-          dias; o id incrementa a cada gap maior, reiniciando por paciente.
+          Identificador da jornada de cuidado ao qual o evento pertence.
+          Jornadas são sequências consecutivas de eventos da mesma paciente
+          cujo intervalo entre datas de referência não excede 180 dias; o id
+          incrementa a cada gap maior, reiniciando por paciente.
 
       # ── pendências atuais ─────────────────────────────────────────────────────
       - name: pendencia_atual

--- a/models/marts/subgeral/monitora_cancer/gravidade_indicador/_gravidade_indicador__schema.yml
+++ b/models/marts/subgeral/monitora_cancer/gravidade_indicador/_gravidade_indicador__schema.yml
@@ -6,7 +6,7 @@ models:
       Score de gravidade da paciente no monitoramento de câncer de mama —
       ordena a fila de cuidado por urgência de contato. Granularidade: 1
       linha por paciente (cpf_particao). Inclui pacientes com pelo menos
-      um critério ativo no run atual OU que são gestantes (gestantes sem
+      um critério ativo na jornada atual OU que são gestantes (gestantes sem
       critério recebem gravidade_total = 0 e gravidade_detalhamento NULL
       — o multiplicador de gestante atua sobre o termo_max e não cria
       score onde não há critério).
@@ -53,11 +53,11 @@ models:
       "todas em emergência absoluta". A ordenação interna ao grupo
       saturado continua sendo via gravidade_total bruto. O teto é
       computado dinamicamente como o p95 da distribuição de
-      gravidade_total do run atual, dispensando recalibração manual
+      gravidade_total da jornada atual, dispensando recalibração manual
       após mudança de pesos/parâmetros.
 
-      Considera apenas eventos do RUN ATUAL (último episódio de cuidado) de
-      cada paciente.
+      Considera apenas eventos da JORNADA ATUAL (a sequência de eventos mais
+      recente) de cada paciente.
 
       Parâmetros (valores vigentes ficam em int_monitora_cancer__gravidade.sql
       e int_monitora_cancer__gravidade_instancias.sql; pesos clínicos na
@@ -212,7 +212,7 @@ models:
 
   - name: mart_monitora_cancer__gravidade_instancias
     description: >
-      Instâncias ativas dos critérios de gravidade no run atual — granula-
+      Instâncias ativas dos critérios de gravidade na jornada atual — granula-
       ridade fina, ANTES do colapso MAX por critério aplicado em
       mart_monitora_cancer__gravidade. Uma linha por (cpf_particao,
       criterio, etapa, data_trigger).

--- a/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
+++ b/models/marts/subgeral/monitora_cancer/mart_monitora_cancer__pacientes_linha_tempo.sql
@@ -99,7 +99,7 @@ select
 
     any_value (ev.tempo_total) as tempo_total,
 
-    -- tempos da linha de cuidado, medidos dentro do run atual (calculados em
+    -- tempos da linha de cuidado, medidos dentro da jornada atual (calculados em
     -- int_monitora_cancer__eventos_episodios; NULL fora do escopo de cada um)
     any_value (ev.tempo_diagnostico) as tempo_diagnostico,
     any_value (ev.tempo_diagnostico_sem_tratamento) as tempo_diagnostico_sem_tratamento,


### PR DESCRIPTION
Status (SUSPEITA/DIAGNOSTICO/UNACON) is now derived only from the
patient's current journey (run_id = max) in eventos_episodios, instead
of the full event history in populacao_alvo. Also standardizes the
"run atual"/"episodio atual" wording to "jornada atual" across docs.