### PR TITLE
Adiciona classificação de diagnósticos nos eventos do PIC e corrige data de diagnóstico do CID no Vitai

### DIFF
--- a/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
+++ b/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
@@ -428,7 +428,7 @@ with
                         cid.descricao
                      ) as descricao,
                     'ATIVO' as situacao,
-                    cast(null as string) as data_diagnostico
+                    cast(date(diagnostico.data) as string) as data_diagnostico
                 )
             ) as condicoes
         from {{ ref('raw_prontuario_vitai__diagnostico')}} as diagnostico

--- a/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
+++ b/models/marts/iplanrio/pic/mart_iplanrio_pic__eventos.sql
@@ -182,6 +182,50 @@ WITH
           ) IS NOT NULL
     ),
 
+    -- DIAGNÓSTICOS
+    -- Identifica CIDs de HIV, sífilis, hepatite B e hepatite C e gera o evento correspondente
+    -- formato "Diagnóstico - <agravo>"
+    diagnosticos AS (
+        SELECT DISTINCT
+            cpf,
+            tipo_evento,
+            dthr
+        FROM (
+            SELECT
+                e.paciente_cpf AS cpf,
+                CASE
+                    WHEN REGEXP_CONTAINS(cid_normalizado, r'^(B20|B21|B22|B23|B24|Z21|O987)')
+                        THEN 'Diagnóstico - HIV'
+
+                    WHEN REGEXP_CONTAINS(cid_normalizado, r'^(A50|A51|A52|A53|O981)')
+                        THEN 'Diagnóstico - Sífilis'
+
+                    WHEN REGEXP_CONTAINS(cid_normalizado, r'^(B16|B180|B181)')
+                        THEN 'Diagnóstico - Hepatite B'
+
+                    WHEN REGEXP_CONTAINS(cid_normalizado, r'^(B171|B182)')
+                        THEN 'Diagnóstico - Hepatite C'
+                END AS tipo_evento,
+                CAST(
+                    SAFE.PARSE_DATE(
+                        '%Y-%m-%d',
+                        SUBSTR(CAST(c.data_diagnostico AS STRING), 1, 10)
+                    ) AS DATETIME
+                ) AS dthr
+            FROM {{ ref("mart_historico_clinico__episodio") }} e
+            LEFT JOIN UNNEST(e.condicoes) c
+            CROSS JOIN UNNEST([
+                REGEXP_REPLACE(UPPER(c.id), r'[^A-Z0-9]', '')
+            ]) AS cid_normalizado
+            WHERE e.paciente_cpf IS NOT NULL
+              AND TRIM(e.paciente_cpf) <> ''
+              AND c.id IS NOT NULL
+              AND c.data_diagnostico IS NOT NULL
+              AND TRIM(CAST(c.data_diagnostico AS STRING)) <> ''
+        )
+        WHERE tipo_evento IS NOT NULL
+    ),
+
     -- VACINAS
     vacinacoes AS (
         SELECT
@@ -246,6 +290,8 @@ WITH
         SELECT * FROM vacinacoes
         UNION ALL
         SELECT * FROM testes_rapidos
+        UNION ALL
+        SELECT * FROM diagnosticos
     ),
 
     eventos_unificados AS (


### PR DESCRIPTION
Revisar a regra de eventos clínicos utilizados pelo PIC para incluir diagnósticos relacionados aos agravos avaliados no protocolo de testes rápidos de gestantes.

## Alterações realizadas

* Incluída a classificação de diagnósticos no modelo `projeto_pic.eventos`.
* Adicionados eventos no formato:

  * `Diagnóstico - HIV`
  * `Diagnóstico - Sífilis`
  * `Diagnóstico - Hepatite B`
  * `Diagnóstico - Hepatite C`
* Os diagnósticos são identificados a partir dos CIDs-alvo definidos para cada agravo.
* Incluída a CTE `diagnosticos` no conjunto final de eventos, junto com consultas, visitas domiciliares, vacinas e testes rápidos.
* Corrigido o modelo `int_historico_clinico__episodio__vitai` para preencher `condicoes.data_diagnostico` com a data do diagnóstico registrada em `raw_prontuario_vitai__diagnostico.data`.

## Motivação

O protocolo de testes rápidos do Pequenos Cariocas deve considerar que, quando a gestante já possui diagnóstico registrado para HIV, sífilis, hepatite B ou hepatite C, a ausência do respectivo teste rápido não deve necessariamente gerar sinalização de irregularidade.

Além disso, foi identificado que os diagnósticos do Vitai possuíam data preenchida na camada raw, mas essa informação era descartada no intermediário, chegando nula ao mart de histórico clínico.

Com essa alteração, o modelo de eventos passa a disponibilizar diagnósticos como evidências clínicas para os protocolos do PIC, permitindo que regras posteriores considerem tanto testes rápidos quanto diagnósticos registrados.