### PR TITLE
feat(dashboard_gestacoes): janela de gestação aberta (gestacoes) + match de CID de HAS por prefixo (linha_tempo)

### DIFF
--- a/models/marts/subpav/dashboard_gestacoes/mart_bi_gestacoes__gestacoes.sql
+++ b/models/marts/subpav/dashboard_gestacoes/mart_bi_gestacoes__gestacoes.sql
@@ -5,7 +5,28 @@
     )
 }}
 
-WITH
+-- ================================================================================================
+-- REGRA "JANELA DE GESTAÇÃO ABERTA" (issue #42 — corrige a duplicação de gestantes)
+-- ------------------------------------------------------------------------------------------------
+-- A regra anterior (agrupamento por gap de 60 dias) fragmentava uma gravidez em várias gestações
+-- ATIVAS simultâneas: qualquer CID de gestação ATIVO recorrente (Z34/Z35, supervisão) ou re-datado
+-- (Z321) virava um novo "início" quando distava >= 60 dias do anterior, e nada encerrava a gestação
+-- por PARTO (só RESOLVIDO). Resultado: 2.054 pacientes com 2-4 gestações abertas ao mesmo tempo.
+--
+-- Nova regra (sessionization recursiva, uma gestação por iteração):
+--   * Uma abertura só cria nova gestação se NÃO cair dentro da janela de uma gestação já aberta.
+--   * Janela = [data_inicio, min(1º fechamento posterior, data_inicio + 299 dias)].
+--   * Fechamentos = RESOLVIDO de CID de gestação  UNIÃO  partos/abortos maternos
+--     (O00-O04, O80-O84, Z37/Z38/Z39; fornecedor vitai; por entrada_data; a partir de 2021).
+--   * data_inicio = PRIMEIRO evento do grupo (corrige M4 — antes pegava o último via DESC).
+--   * data_fim  = fechamento LIMITADO à janela; NULL se a janela venceu por 299 dias (corrige M3).
+--   * Carência de 45 dias pós-fechamento (= janela de puerpério): eventos até 45 dias após um
+--     fechamento real NÃO abrem gestação nova (evita re-stamp puerperal do Z321 criar fantasma).
+--
+-- Contrato de saída inalterado (15 colunas) — proced_2..8 consomem esta tabela sem mudança.
+-- ================================================================================================
+
+WITH RECURSIVE
 
     -- ------------------------------------------------------------
     -- Recuperando dados do Paciente
@@ -19,15 +40,11 @@ WITH
                 dados.data_nascimento,
                 YEAR
             ) AS idade_gestante,
-        FROM {{ ref('mart_historico_clinico__paciente') }}       
+        FROM {{ ref('mart_historico_clinico__paciente') }}
     ),
 
     -- ------------------------------------------------------------
-    -- Eventos de Gestação
-    -- ------------------------------------------------------------
-    -- Seleciona eventos clínicos brutos da tabela episodio_assistencial que podem indicar o início ou fim de uma gestação.
-    -- Filtra por CIDs específicos (Z32.1 - Gravidez confirmada, Z34 - Supervisão de gravidez normal, Z35 - Supervisão de gravidez de alto risco).
-    -- Classifica o tipo_evento como 'gestacao' para os CIDs relevantes.
+    -- Eventos de Gestação (CIDs Z32.1 / Z34% / Z35%), ATIVO ou RESOLVIDO
     -- ------------------------------------------------------------
     eventos_brutos AS (
         SELECT
@@ -42,32 +59,30 @@ WITH
                 '%Y-%m-%d',
                 SUBSTR(c.data_diagnostico, 1, 10)
             ) AS data_evento,
-            -- Identifica o tipo de evento como 'gestacao' com base no CID
             CASE
                 WHEN c.id = 'Z321'
                 OR c.id LIKE 'Z34%'
                 OR c.id LIKE 'Z35%' THEN 'gestacao'
-                ELSE NULL -- Em teoria, o filtro WHERE já garante que só teremos 'gestacao', mas é bom ser explícito
+                ELSE NULL
             END AS tipo_evento
         FROM
             {{ ref('mart_historico_clinico__episodio') }}
-            --Ajuste UNNEST (foi retirado a vírgula ao fim da linha acima)
-            LEFT JOIN UNNEST (condicoes) c -- Expande o array de condições para processar cada uma individualmente
+            LEFT JOIN UNNEST (condicoes) c
             INNER JOIN cadastro_paciente cp ON paciente.id_paciente = cp.id_paciente
         WHERE
             c.data_diagnostico IS NOT NULL
-            AND c.data_diagnostico != '' -- Garante que a data do diagnóstico existe
-            AND c.situacao IN ('ATIVO', 'RESOLVIDO') -- Considera apenas condições ativas ou resolvidas
+            AND c.data_diagnostico != ''
+            AND c.situacao IN ('ATIVO', 'RESOLVIDO')
             AND (
                 c.id = 'Z321'
                 OR c.id LIKE 'Z34%'
                 OR c.id LIKE 'Z35%'
-            ) -- Filtro principal para CIDs de gestação
-            AND paciente.id_paciente IS NOT NULL -- Garante que há um ID de paciente associado
+            )
+            AND paciente.id_paciente IS NOT NULL
     ),
 
     -- ------------------------------------------------------------
-    -- Inícios e Finais de Gestação
+    -- Inícios (ATIVO) e Finais (RESOLVIDO) de gestação
     -- ------------------------------------------------------------
     inicios_brutos AS (
         SELECT *
@@ -85,139 +100,164 @@ WITH
     ),
 
     -- ------------------------------------------------------------
-    -- Inícios de Gestação com Grupo
+    -- NOVO: Partos/abortos maternos — encerram a gestação (não só o RESOLVIDO)
+    -- Fornecedor 'vitai', datado por entrada_data, a partir de 2021.
+    -- CIDs: O00-O04 (gravidez ectópica/aborto), O80-O84 (parto), Z37/Z38/Z39 (resultado/RN/pós-parto).
     -- ------------------------------------------------------------
-    -- Prepara os dados de 'inicios_brutos' para agrupar eventos de início de gestação próximos.
-    -- Usa a função LAG para acessar a data do evento anterior da mesma paciente.
-    -- Define um 'nova_ocorrencia_flag': 1 se for o primeiro evento da paciente ou se houver um intervalo de >= 30 dias desde o evento anterior.
-    -- ------------------------------------------------------------
-    inicios_com_grupo AS (
-        SELECT
-            *,
-            LAG(data_evento) OVER (
-                PARTITION BY
-                    id_paciente
-                ORDER BY data_evento
-            ) AS data_anterior,
-            CASE
-                WHEN LAG(data_evento) OVER (
-                    PARTITION BY
-                        id_paciente
-                    ORDER BY data_evento
-                ) IS NULL THEN 1 -- Primeiro evento da paciente
-                WHEN DATE_DIFF (
-                    data_evento,
-                    LAG(data_evento) OVER (
-                        PARTITION BY
-                            id_paciente
-                        ORDER BY data_evento
-                    ),
-                    DAY
-                ) >= 60 THEN 1 -- Nova gestação se > 60 dias
-                ELSE 0 -- Continuação da mesma "janela" de início de gestação
-            END AS nova_ocorrencia_flag
-        FROM inicios_brutos
-    ),
-
-    -- ------------------------------------------------------------
-    -- Grupos de Inícios de Gestação
-    -- ------------------------------------------------------------
-    -- Cria um 'grupo_id' para cada conjunto de eventos de início de gestação que pertencem à mesma gestação.
-    -- Usa a soma acumulada (SUM OVER) do 'nova_ocorrencia_flag'.
-    -- ------------------------------------------------------------
-    grupos_inicios AS (
-        SELECT *, SUM(nova_ocorrencia_flag) OVER (
-                PARTITION BY
-                    id_paciente
-                ORDER BY data_evento
-            ) AS grupo_id
-        FROM inicios_com_grupo
-    ),
-
-    -- ------------------------------------------------------------
-    -- Inícios de Gestação Deduplicados
-    -- ------------------------------------------------------------
-    -- Seleciona o evento de início mais recente dentro de cada 'grupo_id' para uma paciente.
-    -- Isso ajuda a consolidar múltiplos registros de início próximos no tempo para uma única data de início.
-    -- A ordenação por `data_evento DESC` e `rn = 1` pega o registro mais recente dentro do grupo.
-    -- Se a intenção fosse pegar o primeiro registro do grupo, seria `ASC`. A lógica atual pega o último sinal de "ativo" dentro do grupo.
-    -- ------------------------------------------------------------
-    inicios_deduplicados AS (
-        SELECT *
-        FROM (
-                SELECT *, ROW_NUMBER() OVER (
-                        PARTITION BY
-                            id_paciente, grupo_id
-                        ORDER BY data_evento DESC
-                    ) AS rn
-                FROM grupos_inicios
+    eventos_parto_mae AS (
+        SELECT DISTINCT
+            ea.paciente.id_paciente AS id_paciente,
+            ea.entrada_data AS data_fechamento
+        FROM {{ ref('mart_historico_clinico__episodio') }} ea
+        LEFT JOIN UNNEST (ea.condicoes) c
+        WHERE ea.entrada_data >= DATE '2021-01-01'
+            AND LOWER(ea.prontuario.fornecedor) = 'vitai'
+            AND (
+                REGEXP_CONTAINS(c.id, r'^O0[0-4]')
+                OR REGEXP_CONTAINS(c.id, r'^O8[0-4]')
+                OR c.id LIKE 'Z37%'
+                OR c.id LIKE 'Z38%'
+                OR c.id LIKE 'Z39%'
             )
-        WHERE
-            rn = 1
+            AND ea.paciente.id_paciente IS NOT NULL
     ),
 
     -- ------------------------------------------------------------
-    -- Gestações Únicas
+    -- NOVO: Aberturas (datas ATIVO deduplicadas) e Fechamentos (RESOLVIDO ∪ partos)
     -- ------------------------------------------------------------
-    -- Define cada gestação única com sua data de início e data de fim.
-    -- A data de fim é o primeiro evento 'RESOLVIDO' (de 'finais') que ocorre após a data de início da gestação.
-    -- Gera um 'numero_gestacao' e um 'id_gestacao' único para cada gestação da paciente.
+    aberturas AS (
+        SELECT id_paciente, data_evento
+        FROM inicios_brutos
+        GROUP BY id_paciente, data_evento
+    ),
+    fechamentos AS (
+        SELECT DISTINCT id_paciente, data_evento AS data_fechamento FROM finais
+        UNION DISTINCT
+        SELECT id_paciente, data_fechamento FROM eventos_parto_mae
+    ),
+
+    -- ------------------------------------------------------------
+    -- NOVO: Estado por paciente — arrays ordenados de aberturas (da) e fechamentos (df)
+    -- ------------------------------------------------------------
+    estado_paciente AS (
+        SELECT
+            a.id_paciente,
+            ARRAY_AGG(a.data_evento ORDER BY a.data_evento) AS da,
+            ANY_VALUE(fx.df) AS df,
+            COUNT(*) AS n_aberturas
+        FROM aberturas a
+        LEFT JOIN (
+            SELECT id_paciente, ARRAY_AGG(data_fechamento ORDER BY data_fechamento) AS df
+            FROM fechamentos
+            GROUP BY id_paciente
+        ) fx USING (id_paciente)
+        GROUP BY a.id_paciente
+    ),
+
+    -- ------------------------------------------------------------
+    -- NOVO: Sessionization recursiva — 1 gestação por iteração
+    --   fim_janela = LEAST(1º fechamento > data_inicio, data_inicio + 299 dias)
+    --   próxima abertura = 1ª data em `da` maior que o LIMITE DE CARÊNCIA, onde
+    --   limite = fim_janela + 45 dias se a janela fechou por fechamento real;
+    --           = fim_janela           se venceu por 299 dias (sem carência).
+    -- ------------------------------------------------------------
+    gest_rec AS (
+        -- Termo âncora: 1ª gestação da paciente (1ª abertura)
+        SELECT
+            id_paciente,
+            1 AS n,
+            da[OFFSET(0)] AS data_inicio,
+            LEAST(
+                COALESCE((SELECT MIN(f) FROM UNNEST(df) f WHERE f > da[OFFSET(0)]), DATE '9999-12-31'),
+                DATE_ADD(da[OFFSET(0)], INTERVAL 299 DAY)
+            ) AS fim_janela,
+            da,
+            df
+        FROM estado_paciente
+        WHERE n_aberturas <= 200  -- guarda de segurança contra array patológico
+        UNION ALL
+        -- Termo recursivo: próxima gestação começa na 1ª abertura após a carência
+        SELECT
+            id_paciente,
+            n + 1,
+            (SELECT MIN(d) FROM UNNEST(da) d
+               WHERE d > IF(fim_janela < DATE_ADD(data_inicio, INTERVAL 299 DAY),
+                            DATE_ADD(fim_janela, INTERVAL 45 DAY), fim_janela)),
+            LEAST(
+                COALESCE((
+                    SELECT MIN(f) FROM UNNEST(df) f
+                    WHERE f > (SELECT MIN(d) FROM UNNEST(da) d
+                                 WHERE d > IF(fim_janela < DATE_ADD(data_inicio, INTERVAL 299 DAY),
+                                              DATE_ADD(fim_janela, INTERVAL 45 DAY), fim_janela))
+                ), DATE '9999-12-31'),
+                DATE_ADD((SELECT MIN(d) FROM UNNEST(da) d
+                            WHERE d > IF(fim_janela < DATE_ADD(data_inicio, INTERVAL 299 DAY),
+                                         DATE_ADD(fim_janela, INTERVAL 45 DAY), fim_janela)),
+                         INTERVAL 299 DAY)
+            ),
+            da,
+            df
+        FROM gest_rec
+        WHERE (SELECT MIN(d) FROM UNNEST(da) d
+                 WHERE d > IF(fim_janela < DATE_ADD(data_inicio, INTERVAL 299 DAY),
+                              DATE_ADD(fim_janela, INTERVAL 45 DAY), fim_janela)) IS NOT NULL
+            AND n < 100  -- cap de profundidade (nº máx. de gestações por paciente)
+    ),
+
+    -- ------------------------------------------------------------
+    -- NOVO: Evento representante por abertura (carrega id_hci/cpf/nome/idade; prefere Z321)
+    -- ------------------------------------------------------------
+    evento_representante AS (
+        SELECT
+            id_paciente,
+            data_evento,
+            ARRAY_AGG(
+                STRUCT(id_hci, cpf, nome, idade_gestante)
+                ORDER BY IF(cid = 'Z321', 0, 1), id_hci
+                LIMIT 1
+            )[OFFSET(0)] AS rep
+        FROM inicios_brutos
+        GROUP BY id_paciente, data_evento
+    ),
+
+    -- ------------------------------------------------------------
+    -- Gestações Únicas — projeta a recursão + representante
+    --   data_inicio = 1ª abertura do grupo (M4);  data_fim = fechamento na janela ou NULL (M3).
     -- ------------------------------------------------------------
     gestacoes_unicas AS (
         SELECT
-            i.id_hci,
-            i.id_paciente,
-            i.cpf,
-            i.nome,
-            i.idade_gestante,
-            i.data_evento AS data_inicio,
-            -- Subconsulta para encontrar a data de fim mais próxima após o início
-            (
-                SELECT MIN(f.data_evento)
-                FROM finais f
-                WHERE
-                    f.id_paciente = i.id_paciente
-                    AND f.data_evento > i.data_evento
-            ) AS data_fim,
-            ROW_NUMBER() OVER (
-                PARTITION BY
-                    i.id_paciente
-                ORDER BY i.data_evento
-            ) AS numero_gestacao,
-            CONCAT(
-                i.id_paciente,
-                '-',
-                CAST(
-                    ROW_NUMBER() OVER (
-                        PARTITION BY
-                            i.id_paciente
-                        ORDER BY i.data_evento
-                    ) AS STRING
-                )
-            ) AS id_gestacao
-        FROM inicios_deduplicados i
+            er.rep.id_hci AS id_hci,
+            g.id_paciente,
+            er.rep.cpf AS cpf,
+            er.rep.nome AS nome,
+            er.rep.idade_gestante AS idade_gestante,
+            g.data_inicio,
+            IF(g.fim_janela = DATE_ADD(g.data_inicio, INTERVAL 299 DAY), NULL, g.fim_janela) AS data_fim,
+            g.n AS numero_gestacao,
+            CONCAT(g.id_paciente, '-', CAST(g.n AS STRING)) AS id_gestacao
+        FROM gest_rec g
+        JOIN evento_representante er
+            ON er.id_paciente = g.id_paciente
+            AND er.data_evento = g.data_inicio
     ),
 
     -- ------------------------------------------------------------
-    -- Gestações com Status
-    -- ------------------------------------------------------------
-    -- Calcula a 'data_fim_efetiva' (data de fim real ou estimada após 300 dias se não houver fim registrado e já passou o período).
-    -- Calcula a DPP (Data Provável do Parto) como 40 semanas após a data de início.
+    -- Gestações com Status — data_fim_efetiva (fim real ou +299d) e DPP (inalterado)
     -- ------------------------------------------------------------
     gestacoes_com_status AS (
         SELECT
             *,
             CASE
-                WHEN data_fim IS NOT NULL THEN data_fim -- Usa a data de fim registrada se existir
-                WHEN DATE_ADD(data_inicio, INTERVAL 300 DAY) <= CURRENT_DATE() THEN DATE_ADD(data_inicio, INTERVAL 300 DAY) -- Se passou 300 dias (42sem + 6 dias) e não tem data_fim, considera encerrada
-                ELSE NULL -- Ainda em curso e sem data de fim, ou não atingiu 300 dias. Será tratada pela fase_atual.
+                WHEN data_fim IS NOT NULL THEN data_fim
+                WHEN DATE_ADD(data_inicio, INTERVAL 299 DAY) <= CURRENT_DATE() THEN DATE_ADD(data_inicio, INTERVAL 299 DAY)
+                ELSE NULL
             END AS data_fim_efetiva,
             DATE_ADD(data_inicio, INTERVAL 40 WEEK) AS dpp
         FROM gestacoes_unicas
     ),
 
     -- ------------------------------------------------------------
-    -- Definição de Fase e Trimestre da Gestação
+    -- Fase e Trimestre da Gestação (inalterado)
     -- ------------------------------------------------------------
     filtrado AS (
         SELECT
@@ -226,17 +266,16 @@ WITH
                 WHEN gcs.data_fim IS NULL
                 AND DATE_ADD(
                     gcs.data_inicio,
-                    INTERVAL 300 DAY
-                ) > CURRENT_DATE() THEN 'Gestação' -- Sem data de fim e dentro dos 300 dias esperados
+                    INTERVAL 299 DAY
+                ) > CURRENT_DATE() THEN 'Gestação'
                 WHEN gcs.data_fim IS NOT NULL
                 AND DATE_DIFF (
                     CURRENT_DATE(),
                     gcs.data_fim,
                     DAY
-                ) <= 45 THEN 'Puerpério' -- Com data de fim, e dentro de 45 dias do fim
-                ELSE 'Encerrada' -- Outros casos (com data de fim e > 45 dias, ou sem data de fim mas > 300 dias)
+                ) <= 45 THEN 'Puerpério'
+                ELSE 'Encerrada'
             END AS fase_atual,
-            -- Adicionando o cálculo do trimestre aqui para evitar uma CTE separada depois
             CASE
                 WHEN DATE_DIFF (
                     CURRENT_DATE(),
@@ -253,13 +292,13 @@ WITH
                     gcs.data_inicio,
                     WEEK
                 ) >= 28 THEN '3º trimestre'
-                ELSE 'Data inválida ou encerrada' -- Pode precisar ajustar essa lógica se `fase_atual` != 'Gestação'
-            END AS trimestre_atual_gestacao -- Renomeado para clareza
+                ELSE 'Data inválida ou encerrada'
+            END AS trimestre_atual_gestacao
         FROM gestacoes_com_status gcs
     ),
 
     -- ------------------------------------------------------------
-    -- Descobrindo Equipe da Saúde da Gestação
+    -- Equipe de Saúde da Família vigente na gestação (inalterado)
     -- ------------------------------------------------------------
     unnested_equipes AS (
         SELECT
@@ -268,22 +307,19 @@ WITH
             eq.nome AS equipe_nome,
             eq.clinica_familia.nome AS clinica_nome
         FROM
-            -- {{ ref('mart_historico_clinico__paciente') }} p,
             {{ ref('mart_historico_clinico__paciente') }} p
-            --Ajuste UNNEST (foi retirado a vírgula ao fim da linha acima)
             left join UNNEST (p.equipe_saude_familia) AS eq
     ),
     equipe_durante_gestacao AS (
-        SELECT f.id_gestacao, -- Chave para JOIN posterior
+        SELECT f.id_gestacao,
             eq.equipe_nome, eq.clinica_nome, ROW_NUMBER() OVER (
                 PARTITION BY
-                    f.id_gestacao -- Modificado para id_gestacao para garantir unicidade por gestação
+                    f.id_gestacao
                 ORDER BY eq.datahora_ultima_atualizacao DESC
             ) AS rn
         FROM
             filtrado f
                 LEFT JOIN unnested_equipes eq ON f.id_paciente = eq.id_paciente
-            -- A equipe deve ter sido atualizada ANTES ou NO MÁXIMO na data de fim da gestação
             AND DATE(
                 eq.datahora_ultima_atualizacao
             ) <= COALESCE(
@@ -302,7 +338,7 @@ WITH
     )
 
 -- ------------------------------------------------------------
--- Finalização do Modelo
+-- Finalização do Modelo (15 colunas — contrato inalterado)
 -- ------------------------------------------------------------
 SELECT
     filtrado.id_hci,

--- a/models/marts/subpav/dashboard_gestacoes/mart_bi_gestacoes__linha_tempo.sql
+++ b/models/marts/subpav/dashboard_gestacoes/mart_bi_gestacoes__linha_tempo.sql
@@ -1060,17 +1060,17 @@ encaminhamento_hipertensao_sisreg AS (
         AND (
             s.sisreg_primeira_cid LIKE 'O10%'
             OR -- Hipertensão prévia
-            REGEXP_CONTAINS(s.sisreg_primeira_cid, r'\bI1[0-5]\b')
+            REGEXP_CONTAINS(s.sisreg_primeira_cid, r'^I1[0-5]')
             OR -- Hipertensão essencial
-            s.sisreg_primeira_cid = 'O11'
+            s.sisreg_primeira_cid LIKE 'O11%'
             OR -- Pré-eclâmpsia superposta
-            s.sisreg_primeira_cid = 'O13'
+            s.sisreg_primeira_cid LIKE 'O13%'
             OR -- Hipertensão gestacional
-            s.sisreg_primeira_cid = 'O14'
+            s.sisreg_primeira_cid LIKE 'O14%'
             OR -- Pré-eclâmpsia
-            s.sisreg_primeira_cid = 'O15'
+            s.sisreg_primeira_cid LIKE 'O15%'
             OR -- Eclâmpsia
-            s.sisreg_primeira_cid = 'O16' -- Hipertensão não especificada
+            s.sisreg_primeira_cid LIKE 'O16%' -- Hipertensão não especificada
         )
         AND DATE(s.sisreg_primeira_data_solicitacao) BETWEEN f.data_inicio AND COALESCE(
             f.data_fim_efetiva,
@@ -1113,17 +1113,17 @@ encaminhamento_hipertensao_SER AS (
         AND (
             s.ser_descricao_cid LIKE 'O10%'
             OR -- Hipertensão prévia
-            REGEXP_CONTAINS(s.ser_descricao_cid, r'\bI1[0-5]\b')
+            REGEXP_CONTAINS(s.ser_descricao_cid, r'^I1[0-5]')
             OR -- Hipertensão essencial
-            s.ser_descricao_cid = 'O11'
+            s.ser_descricao_cid LIKE 'O11%'
             OR -- Pré-eclâmpsia superposta
-            s.ser_descricao_cid = 'O13'
+            s.ser_descricao_cid LIKE 'O13%'
             OR -- Hipertensão gestacional
-            s.ser_descricao_cid = 'O14'
+            s.ser_descricao_cid LIKE 'O14%'
             OR -- Pré-eclâmpsia
-            s.ser_descricao_cid = 'O15'
+            s.ser_descricao_cid LIKE 'O15%'
             OR -- Eclâmpsia
-            s.ser_descricao_cid = 'O16' -- Hipertensão não especificada
+            s.ser_descricao_cid LIKE 'O16%' -- Hipertensão não especificada
         )
         AND DATE(s.ser_data_agendamento) BETWEEN f.data_inicio AND COALESCE(
             f.data_fim_efetiva,


### PR DESCRIPTION
## Contexto
Duas correções nos modelos de `marts/subpav/dashboard_gestacoes`, vindas da refatoração do Monitor Gestante (SMS-RJ). Cada uma foi validada em BigQuery antes de portar para o dbt.

## 1. `mart_bi_gestacoes__gestacoes` — regra "janela de gestação aberta"
**Problema:** o agrupamento por gap de 60 dias fragmentava uma mesma gravidez em 2–4 gestações **ATIVAS simultâneas** da mesma paciente (CIDs de supervisão Z34/Z35 recorrentes ou Z321 re-datado viravam novos "inícios"; nada encerrava por parto, só por `RESOLVIDO`). Isso gerava linhas-fantasma e double-count a jusante.

**Correção:** sessionization recursiva (`WITH RECURSIVE`):
- uma abertura só cria nova gestação se **não** cair dentro da janela de uma já aberta;
- janela = `[data_inicio, min(1º fechamento posterior, data_inicio + 299 dias)]`;
- fechamentos = `RESOLVIDO` ∪ partos/abortos maternos (O00–O04, O80–O84, Z37/Z38/Z39; fornecedor vitai; ≥ 2021);
- `data_inicio` = **primeiro** evento do grupo; `data_fim` limitado à janela; carência de 45 dias pós-fechamento (puerpério).

**Contrato de saída inalterado (15 colunas)** — modelos a jusante não mudam.

## 2. `mart_bi_gestacoes__linha_tempo` — match de CID de HAS por prefixo
**Problema:** o filtro de CID hipertensivo no encaminhamento usava `=` exato de 3 caracteres (`'O11'`,`'O13'`…) e `REGEXP '\\bI1[0-5]\\b'`. Como ~38% dos CIDs têm 4 dígitos, isso **descartava** formas graves: O140/O149 (pré-eclâmpsia), O150/O151/O159 (eclâmpsia), I110/I150.

**Correção:** match por **prefixo** — `LIKE 'O1x%'` e `REGEXP '^I1[0-5]'` — nos dois blocos (SISREG e SER). Diff mínimo (12 linhas).

## Validação
- `dbt parse` do projeto com os 2 arquivos: sem erro (refs/Jinja/config OK).
- Dry-run no BigQuery da lógica do `gestacoes`: query válida.
- O `linha_tempo` preserva o line-ending original (CRLF) do arquivo; só as linhas do CID mudam.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> A reescrita da lógica central de `gestacoes` altera linhas, `id_gestacao`, fases e janelas em todo o dashboard; o match de CID em `linha_tempo` muda quem entra nos indicadores de encaminhamento HAS.
> 
> **Overview**
> **`mart_bi_gestacoes__gestacoes`** deixa de agrupar inícios por gap de 60 dias e passa a **sessionização recursiva** (“janela de gestação aberta”): nova gestação só se a abertura cair fora da janela `[data_inicio, min(1º fechamento, +299 dias)]`, com **45 dias de carência** após fechamento real. **Fechamentos** incluem `RESOLVIDO` de CIDs de gestação **e** partos/abortos maternos (Vitai, ≥2021). **`data_inicio`** passa a ser o **primeiro** evento do grupo (não o último `ATIVO` do grupo); **`data_fim`** fica limitada à janela (299 dias sem fechamento → `NULL`). Limiares de fase/status alinham **300 → 299 dias**. Saída mantém **15 colunas**; modelos que consomem `gestacoes` (ex.: `linha_tempo`, `encaminhamentos`, `atendimentos_prenatal_aps`) herdam contagens e janelas temporais corrigidas.
> 
> **`mart_bi_gestacoes__linha_tempo`** ajusta filtros de encaminhamento por hipertensão (SISREG e SER): CIDs **`O11`–`O16`** e **`I10`–`I15`** passam de igualdade/regex com word boundary para **`LIKE 'O1x%'`** e **`REGEXP '^I1[0-5]'`**, capturando códigos com 4+ caracteres (ex. O140, I110).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8248c82ad146a8b65b063c708f0090237a944dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->