### PR TITLE
❌ ERROR DBT: mart_subgeral__indicadores_acessos_aps

### DIFF
--- a/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
+++ b/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
@@ -3,7 +3,7 @@
     schema = "projeto_aps_reports",
     alias = "indicadores_acesso_aps",
     unique_key = "data_referencia",
-    meta={"owner": "karen"}
+    meta={"owner": "karen", "team": "subgeral"}
 ) }}
 
 -- Seleciona tipos de atendimento com pelo menos 30% realizados por médicos (CBO 225 ou 2231)

--- a/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
+++ b/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
@@ -12,12 +12,12 @@ WITH tipos_com_medico_30pct AS (
   FROM {{ ref("raw_prontuario_vitacare__atendimento") }}
   WHERE tipo_consulta IS NOT NULL
   GROUP BY tipo_consulta
-  HAVING 
+  HAVING
     SUM(
-      CASE 
+      CASE
         WHEN LEFT(cbo_profissional, 3) = '225'
           OR LEFT(cbo_profissional, 4) = '2231'
-        THEN 1 ELSE 0 
+        THEN 1 ELSE 0
       END
     ) * 1.0 / COUNT(*) >= 0.30
     AND tipo_consulta NOT LIKE '%Gestão%'
@@ -51,20 +51,25 @@ pacientes_contagem AS (
     COUNT(*) AS total_consultas
   FROM atendimentos_validos
   GROUP BY cpf
-)
+),
 
 -- Indicadores de acesso à Atenção Primária à Saúde
-SELECT
-  CURRENT_DATETIME() AS data_referencia,
-  -- Total de pacientes com qualquer cadastro (definitivo e temporário)
-  (SELECT COUNT(*) FROM {{ ref("raw_prontuario_vitacare__paciente") }}) AS acesso_potencial,
-  -- Pacientes com pelo menos 1 consulta médica nos últimos 12 meses
-  (SELECT COUNT(*) FROM pacientes_contagem WHERE total_consultas >= 1) AS acesso_realizado,
-  -- Pacientes com 3 ou mais consultas médicas no mesmo período
-  (SELECT COUNT(*) FROM pacientes_contagem WHERE total_consultas >= 3) AS acesso_efetivo
+indicadores AS (
+  SELECT
+    CURRENT_DATETIME() AS data_referencia,
+    -- Total de pacientes com qualquer cadastro (definitivo e temporário)
+    (SELECT COUNT(*) FROM {{ ref("raw_prontuario_vitacare__paciente") }}) AS acesso_potencial,
+    -- Pacientes com pelo menos 1 consulta médica nos últimos 12 meses
+    (SELECT COUNT(*) FROM pacientes_contagem WHERE total_consultas >= 1) AS acesso_realizado,
+    -- Pacientes com 3 ou mais consultas médicas no mesmo período
+    (SELECT COUNT(*) FROM pacientes_contagem WHERE total_consultas >= 3) AS acesso_efetivo
+)
+
+SELECT *
+FROM indicadores
 
 {% if is_incremental() %}
-  WHERE CURRENT_DATETIME() NOT IN (
+WHERE data_referencia NOT IN (
     SELECT data_referencia FROM {{ this }}
   )
 {% endif %}

--- a/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
+++ b/models/marts/subgeral/reports/indicadores_aps_reports/mart_subgeral__indicadores_acessos_aps.sql
@@ -2,7 +2,8 @@
     materialized = "incremental",
     schema = "projeto_aps_reports",
     alias = "indicadores_acesso_aps",
-    unique_key = "data_referencia"
+    unique_key = "data_referencia",
+    meta={"owner": "karen"}
 ) }}
 
 -- Seleciona tipos de atendimento com pelo menos 30% realizados por médicos (CBO 225 ou 2231)


### PR DESCRIPTION
Corrige a estrutura do modelo `mart_subgeral__indicadores_acessos_aps` para evitar erro no BigQuery durante execução incremental.

O cálculo final dos indicadores foi encapsulado em uma CTE `indicadores`, permitindo aplicar o filtro incremental sobre um `SELECT * FROM indicadores`. A lógica de cálculo dos campos `acesso_potencial`, `acesso_realizado` e `acesso_efetivo` foi preservada.