### PR TITLE
HCI/Vitai - Adiciona coalesce para data de saída do episódio assistencial

### DIFF
--- a/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
+++ b/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
@@ -22,6 +22,7 @@ with
     alta_adm as ( -- Alta administrativa (consultas)
         select
             gid_boletim,
+            alta_data,
             CASE
                 WHEN
                     {{ process_null("alta_tipo_detalhado") }} is null and {{clean_abe_obs('abe_obs')}} is null THEN null 
@@ -92,7 +93,11 @@ with
             b.imported_at,
             b.updated_at,
             {{ parse_and_filter_future_datetime('b.data_entrada') }} as entrada_datahora,
-            {{ parse_and_filter_future_datetime('b.alta_data') }} as saida_datahora,
+            coalesce(
+                b.alta_data,
+                aa.alta_data,
+                ai.resumo_alta_datahora
+            ) as saida_datahora,
             if(
                 {{ process_null(clean_numeric("b.cpf")) }} is null,
                 {{ process_null(clean_numeric("paciente_mrg.cpf")) }},
@@ -102,6 +107,8 @@ with
             paciente_mrg.data_nascimento
         from {{ ref("raw_prontuario_vitai__boletim") }} as b
         left join paciente_mrg on b.gid_paciente = paciente_mrg.id_paciente
+        left join alta_adm aa on b.gid = aa.gid_boletim
+        left join alta_internacao ai on b.gid = ai.gid_boletim
     ),
     -- Profissional com nome próprio tratado
     profissional_int as (
@@ -535,8 +542,8 @@ with
             exames_realizados,
 
             -- Entrada e Saída
-            atendimento_struct.entrada_datahora as entrada_datahora,
-            atendimento_struct.saida_datahora as saida_datahora,
+            {{ parse_and_filter_future_datetime('atendimento_struct.entrada_datahora') }} as entrada_datahora,
+            {{ parse_and_filter_future_datetime('atendimento_struct.saida_datahora') }} as saida_datahora,
 
             -- Motivo e Desfecho
             safe_cast(

--- a/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
+++ b/models/intermediate/dit/historico_clinico/episodio/int_historico_clinico__episodio__vitai.sql
@@ -92,7 +92,7 @@ with
             internacao_data,
             b.imported_at,
             b.updated_at,
-            {{ parse_and_filter_future_datetime('b.data_entrada') }} as entrada_datahora,
+            b.data_entrada as entrada_datahora,
             coalesce(
                 b.alta_data,
                 aa.alta_data,

--- a/models/raw/prontuario_vitai/raw_prontuario_vitai__alta.sql
+++ b/models/raw/prontuario_vitai/raw_prontuario_vitai__alta.sql
@@ -61,7 +61,7 @@ select
     safe_cast(tipo_alta_detalhada as string) as alta_tipo_detalhado,
     safe_cast(tipo_alta as string) as alta_tipo,
     safe_cast(data_obito as string) as obito_data,
-    safe_cast(data_alta as string) as alta_data,
+    safe_cast(data_alta as datetime) as alta_data,
     safe_cast(motivo_saida as string) as saida_motivo,
     safe_cast(alta_medica as string) as alta_medica,
     safe_cast(alta_administrativa as timestamp) as alta_administrativa_data,


### PR DESCRIPTION
**Resolve casos de internações sem data de desfecho nos episódios da Vitai.**

## Resumo

Utiliza `coalesce` para determinar a data de alta, considerando as seguintes colunas, em ordem de prioridade:
- `data_alta` da tabela `boletim`;
- `data_alta` da tabela `alta`;
- `resumo_alta_datahora` da tabela `resumo_alta`.

## Possível origem do problema

Anteriormente, a data de saída era obtida exclusivamente a partir da coluna `alta_data` da tabela `boletim`. Porém, por algum motivo, esse campo consta como `null` em alguns registros do nosso Data Lake (staging), embora a data de alta estivesse corretamente preenchida nas demais tabelas (`alta` e `resumo_alta`).

Ao verificar a fonte (Base Central), constatamos que, na data de hoje (22/07/2026), os campos já estão preenchidos. A hipótese é de que, no momento das extrações, o campo ainda estava `null`, sendo preenchido posteriormente (fora da nossa janela de extração).

## Conclusão

Essa alteração tem como objetivo solucionar de forma imediata eventuais lacunas na data de alta, utilizando como alternativa as datas disponíveis nas outras tabelas. Ainda assim, registros com atualização "tardia" (fora da janela de extração) devem ser corrigidos por meio da extração mensal do Vitai.