### PR TITLE
chore: limpa nomes de unidades

### DIFF
--- a/models/intermediate/dit/historico_clinico/exames/int_historico_clinico__exames__medilab.sql
+++ b/models/intermediate/dit/historico_clinico/exames/int_historico_clinico__exames__medilab.sql
@@ -27,7 +27,7 @@ with
     agregado as (
         select
             ex.id_cnes,
-            nome_limpo as unidade_nome,
+            {{ proper_estabelecimento("nome_limpo") }} as unidade_nome,
 
             paciente_cpf,
             paciente_cns,

--- a/models/intermediate/dit/historico_clinico/exames/int_historico_clinico__exames_laboratoriais.sql
+++ b/models/intermediate/dit/historico_clinico/exames/int_historico_clinico__exames_laboratoriais.sql
@@ -16,10 +16,20 @@ with
         select
             id,
             paciente_cpf,
-            -- Remove "SMS RIO" do início do nome da unidade
+            -- Limpa nome da unidade
             REGEXP_REPLACE(
-                unidade,
-                r"(?i)^SMS\s+(RIO)?\s*",
+                REGEXP_REPLACE(
+                    REGEXP_REPLACE(
+                        unidade,
+                        r"(?i)\bCl[ií]nica da Fam[ií]lia\b",
+                        "CF"
+                    ),
+                    -- Remove "SMS RIO", número de AP do início
+                    r"(?i)^(SMS|RIO\b|(AP)?[0-9\.\s]*\b|\s)+",
+                    ""
+                ),
+                -- Remove número de AP do final
+                r"(?i)\bAP[0-9\.\s]+$",
                 ""
             ) as unidade_nome,
             laudo_url,

--- a/models/marts/dit/historico_clinico/mart_historico_clinico__exame_imagem.sql
+++ b/models/marts/dit/historico_clinico/mart_historico_clinico__exame_imagem.sql
@@ -11,9 +11,9 @@
     )
 }}
 
-with 
+with
     medilab_exames as (
-        select 
+        select
             *
         from {{ ref('int_historico_clinico__exames__medilab') }}
     ),
@@ -37,7 +37,7 @@ with
             medico_responsavel as medico_responsavel,
             medico_revisor as medico_revisor,
 
-            safe_cast(paciente_cpf as int) as cpf_particao 
+            safe_cast(paciente_cpf as int) as cpf_particao
         from medilab_exames
     )
 


### PR DESCRIPTION
Chama `proper_estabelecimento(...)` em exames de imagem; trata melhor nomes em exames lab