### PR TITLE
Adiciona enriquecimento de CPFs nulos para dados da Vitacare via bcadastro

### DIFF
--- a/models/intermediate/dit/cadastro/_int_bcadastro__cpf_indice.yml
+++ b/models/intermediate/dit/cadastro/_int_bcadastro__cpf_indice.yml
@@ -1,0 +1,50 @@
+version: 2
+
+models:
+  - name: int_bcadastro__cpf_indice
+    description: >
+      Índice semanal do bcadastro para busca de CPF por nome, data de nascimento
+      e nome da mãe normalizados. Contém somente CPFs válidos e cadastros com os
+      três atributos necessários para o cruzamento.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - cpf
+            - nome_normalizado
+            - data_nascimento
+            - mae_nome_normalizado
+    columns:
+      - name: cpf
+        description: CPF válido disponível para enriquecimento.
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
+        data_tests:
+          - not_null
+
+      - name: nome_normalizado
+        description: Nome sem acentos, em maiúsculas e sem espaços duplicados.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
+
+      - name: primeiro_nome_normalizado
+        description: Primeiro nome usado na geração da partição de busca.
+        policy_tags:
+          - '{{ var("TAG_NOME") }}'
+
+      - name: data_nascimento
+        description: Data de nascimento usada na correspondência exata.
+        policy_tags:
+          - '{{ var("TAG_DATA_NASCIMENTO") }}'
+
+      - name: mae_nome_normalizado
+        description: Nome da mãe normalizado usado na correspondência exata.
+        policy_tags:
+          - '{{ var("TAG_NOME_MAE") }}'
+
+      - name: hash_particao
+        description: Partição de busca derivada do primeiro nome normalizado.
+        data_tests:
+          - not_null
+
+      - name: hash_match
+        description: Hash de nome, data de nascimento e nome da mãe normalizados.

--- a/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
+++ b/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
@@ -1,0 +1,64 @@
+{{
+    config(
+        alias="bcadastro_cpf_indice",
+        materialized="table",
+        partition_by={
+            "field": "hash_particao",
+            "data_type": "int64",
+            "range": {"start": 0, "end": 1024, "interval": 1},
+        },
+        cluster_by=["hash_match"],
+        tags=["weekly"]
+    )
+}}
+
+with
+    normalizado as (
+        select
+            {{ clean_numeric("cpf") }} as cpf,
+            nullif(
+                {{ remove_duplicate_whitespace(remove_accents_upper("nome")) }},
+                ""
+            ) as nome_normalizado,
+            nascimento_data as data_nascimento,
+            nullif(
+                {{ remove_duplicate_whitespace(remove_accents_upper("mae_nome")) }},
+                ""
+            ) as mae_nome_normalizado
+        from {{ ref("raw_bcadastro__cpf") }}
+    ),
+
+    com_primeiro_nome as (
+        select
+            *,
+            split(nome_normalizado, " ")[safe_offset(0)] as primeiro_nome_normalizado
+        from normalizado
+        where
+            {{ validate_cpf("cpf") }}
+            and nome_normalizado is not null
+            and data_nascimento is not null
+            and mae_nome_normalizado is not null
+    ),
+
+    com_hashes as (
+        select
+            cpf,
+            nome_normalizado,
+            primeiro_nome_normalizado,
+            data_nascimento,
+            mae_nome_normalizado,
+            mod(abs(farm_fingerprint(primeiro_nome_normalizado)), 1024) as hash_particao,
+            farm_fingerprint(
+                concat(
+                    nome_normalizado,
+                    "|",
+                    format_date("%F", data_nascimento),
+                    "|",
+                    mae_nome_normalizado
+                )
+            ) as hash_match
+        from com_primeiro_nome
+    )
+
+select distinct *
+from com_hashes

--- a/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
+++ b/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
@@ -1,6 +1,7 @@
 {{
     config(
-        alias="bcadastro_cpf_indice",
+        schema="intermediario_cadastro",
+        alias="cpf_indice",
         materialized="table",
         partition_by={
             "field": "hash_particao",

--- a/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
+++ b/models/intermediate/dit/cadastro/int_bcadastro__cpf_indice.sql
@@ -26,7 +26,7 @@ with
                 {{ remove_duplicate_whitespace(remove_accents_upper("mae_nome")) }},
                 ""
             ) as mae_nome_normalizado
-        from {{ ref("raw_bcadastro__cpf") }}
+        from {{ ref("raw_bcadastro__cpf") }} as bcadastro
     ),
 
     com_primeiro_nome as (

--- a/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente__schema.yml
+++ b/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente__schema.yml
@@ -4,7 +4,9 @@ models:
   - name: int_prontuario_vitacare__paciente
     description: >
       Tabela intermediária derivada de `raw_prontuario_vitacare__paciente`,
-      contendo apenas registros com CPF e CNES preenchidos.
+      contendo apenas registros com CPF e CNES preenchidos. Para pacientes cujo
+      CPF original é nulo, utiliza o CPF enriquecido pelo bcadastro quando a
+      correspondência cadastral possui um único CPF candidato.
 
     columns:
       - name: id_paciente_global
@@ -34,7 +36,9 @@ models:
         description: Número do prontuário do paciente.
 
       - name: cpf
-        description: CPF do paciente.
+        description: >
+          CPF original da VitaCare ou, quando o original é nulo, CPF enriquecido
+          pelo bcadastro por correspondência cadastral única.
         policy_tags:
           - '{{ var("TAG_CPF") }}'
         data_tests:

--- a/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente_cpf_enriquecido.yml
+++ b/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente_cpf_enriquecido.yml
@@ -1,0 +1,27 @@
+version: 2
+
+models:
+  - name: int_prontuario_vitacare__paciente_cpf_enriquecido
+    description: >
+      Resultado semanal da busca de CPF para pacientes da VitaCare cujo CPF é
+      nulo. O CPF é disponibilizado somente quando nome, data de nascimento e
+      nome da mãe encontram exatamente um CPF distinto no índice do bcadastro.
+    columns:
+      - name: id_paciente_global
+        description: Identificador do paciente na VitaCare.
+        data_tests:
+          - unique
+          - not_null
+
+      - name: cpf_enriquecido
+        description: CPF obtido do bcadastro quando há um único candidato.
+        policy_tags:
+          - '{{ var("TAG_CPF") }}'
+
+      - name: quantidade_cpf_candidatos
+        description: Quantidade de CPFs distintos encontrados para o paciente.
+
+      - name: resultado_enriquecimento
+        description: >
+          Resultado da busca: CPF_UNICO, SEM_CANDIDATO ou MULTIPLOS_CPFS.
+

--- a/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente_cpf_enriquecido.yml
+++ b/models/intermediate/dit/vitacare/_int_prontuario_vitacare__paciente_cpf_enriquecido.yml
@@ -25,3 +25,8 @@ models:
         description: >
           Resultado da busca: CPF_UNICO, SEM_CANDIDATO ou MULTIPLOS_CPFS.
 
+      - name: processed_at
+        description: >
+          Data e hora em que o enriquecimento foi executado. Indica a validade
+          do dado, pois o modelo é atualizado semanalmente.
+

--- a/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente.sql
+++ b/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente.sql
@@ -7,7 +7,18 @@
     )
 }}
 
-select *
-from {{ ref('raw_prontuario_vitacare__paciente') }}
-where cpf is not null
-  and id_cnes is not null
+select
+    paciente.* replace (
+        coalesce(paciente.cpf, enriquecimento.cpf_enriquecido) as cpf,
+        {{
+            validate_cpf(
+                "coalesce(paciente.cpf, enriquecimento.cpf_enriquecido)"
+            )
+        }} as cpf_valido_indicador
+    )
+from {{ ref("raw_prontuario_vitacare__paciente") }} as paciente
+left join {{ ref("int_prontuario_vitacare__paciente_cpf_enriquecido") }} as enriquecimento
+    on paciente.id_paciente_global = enriquecimento.id_paciente_global
+where
+    coalesce(paciente.cpf, enriquecimento.cpf_enriquecido) is not null
+    and paciente.id_cnes is not null

--- a/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
+++ b/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
@@ -1,0 +1,77 @@
+{{
+    config(
+        schema="intermediario_prontuario_vitacare",
+        alias="paciente_cpf_enriquecido",
+        materialized="table",
+        cluster_by=["id_paciente_global"],
+        tags=["weekly"]
+    )
+}}
+
+with
+    pacientes_sem_cpf as (
+        select
+            id_paciente_global,
+            nullif({{ remove_duplicate_whitespace("nome") }}, "") as nome_normalizado,
+            data_nascimento,
+            nullif({{ remove_duplicate_whitespace("mae_nome") }}, "") as mae_nome_normalizado
+        from {{ ref("raw_prontuario_vitacare__paciente") }}
+        where cpf is null
+    ),
+
+    pacientes_elegiveis as (
+        select
+            *,
+            split(nome_normalizado, " ")[safe_offset(0)] as primeiro_nome_normalizado
+        from pacientes_sem_cpf
+        where
+            nome_normalizado is not null
+            and data_nascimento is not null
+            and mae_nome_normalizado is not null
+    ),
+
+    pacientes_com_hashes as (
+        select
+            *,
+            mod(abs(farm_fingerprint(primeiro_nome_normalizado)), 1024) as hash_particao,
+            farm_fingerprint(
+                concat(
+                    nome_normalizado,
+                    "|",
+                    format_date("%F", data_nascimento),
+                    "|",
+                    mae_nome_normalizado
+                )
+            ) as hash_match
+        from pacientes_elegiveis
+    ),
+
+    candidatos as (
+        select
+            paciente.id_paciente_global,
+            count(distinct indice.cpf) as quantidade_cpf_candidatos,
+            if(
+                count(distinct indice.cpf) = 1,
+                any_value(indice.cpf),
+                null
+            ) as cpf_enriquecido
+        from pacientes_com_hashes as paciente
+        left join {{ ref("int_bcadastro__cpf_indice") }} as indice
+            on paciente.hash_particao = indice.hash_particao
+            and paciente.hash_match = indice.hash_match
+            and paciente.nome_normalizado = indice.nome_normalizado
+            and paciente.data_nascimento = indice.data_nascimento
+            and paciente.mae_nome_normalizado = indice.mae_nome_normalizado
+        group by paciente.id_paciente_global
+    )
+
+select
+    id_paciente_global,
+    cpf_enriquecido,
+    quantidade_cpf_candidatos,
+    case
+        when quantidade_cpf_candidatos = 0 then "SEM_CANDIDATO"
+        when quantidade_cpf_candidatos = 1 then "CPF_UNICO"
+        else "MULTIPLOS_CPFS"
+    end as resultado_enriquecimento
+from candidatos

--- a/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
+++ b/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
@@ -12,9 +12,9 @@ with
     pacientes_sem_cpf as (
         select
             id_paciente_global,
-            nullif({{ remove_duplicate_whitespace("nome") }}, "") as nome_normalizado,
+            nullif({{ remove_duplicate_whitespace(remove_accents_upper("nome")) }}, "") as nome_normalizado,
             data_nascimento,
-            nullif({{ remove_duplicate_whitespace("mae_nome") }}, "") as mae_nome_normalizado
+            nullif({{ remove_duplicate_whitespace(remove_accents_upper("mae_nome")) }}, "") as mae_nome_normalizado
         from {{ ref("raw_prontuario_vitacare__paciente") }}
         where cpf is null
     ),

--- a/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
+++ b/models/intermediate/dit/vitacare/int_prontuario_vitacare__paciente_cpf_enriquecido.sql
@@ -73,5 +73,6 @@ select
         when quantidade_cpf_candidatos = 0 then "SEM_CANDIDATO"
         when quantidade_cpf_candidatos = 1 then "CPF_UNICO"
         else "MULTIPLOS_CPFS"
-    end as resultado_enriquecimento
+    end as resultado_enriquecimento,
+    current_timestamp() as processed_at
 from candidatos


### PR DESCRIPTION
# Novos modelos:

### 1. `int_bcadastro__cpf_indice`

**Objetivo:** criar uma versão otimizada do bcadastro para busca de CPF. Serve como uma tabela auxiliar de índice.

**Necessidade:** como o paciente da VitaCare está sem CPF, não dá para cruzar por CPF. Então a busca precisa ser feita por:

nome + data de nascimento + nome da mãe

O problema é que procurar isso diretamente no bcadastro bruto é caro. Então esse modelo é utilizado como uma tabela auxiliar com apenas os campos necessários e com chaves de busca:

* cpf
* nome_normalizado
* primeiro_nome_normalizado
* data_nascimento
* mae_nome_normalizado
* hash_particao
* hash_match

Ele não enriquece nada. Ele apenas prepara o bcadastro para ser consultado de forma mais barata.

Sem esse modelo, o enriquecimento teria que consultar o bcadastro bruto diretamente, com mais custo e menos organização.

---

### 2. `int_prontuario_vitacare__paciente_cpf_enriquecido`

**Objetivo:** aplicar a regra de enriquecimento nos pacientes da VitaCare sem CPF.

**Necessidade:** esse é o modelo que faz o trabalho de tentar encontrar CPF para cada paciente sem CPF da VitaCare.

Ele pega:

pacientes sem CPF da VitaCare + `int_bcadastro__cpf_indice`

e responde:

* Achei CPF?
* Achei exatamente 1 CPF?
* Achei nenhum?
* Achei mais de um?
* Qual CPF pode ser usado?
* Qual foi o resultado do enriquecimento?

E gera os campos:

* id_paciente_global
* cpf_enriquecido
* quantidade_cpf_candidatos
* resultado_enriquecimento (`CPF_UNICO`, `SEM_CANDIDATO` ou `MULTIPLOS_CPFS`)
* datahora_processamento

Esse modelo também serve para rastreabilidade. Ele permite auditar depois quem foi enriquecido, quem não foi e por quê, além de indicar a validade do dado pelo timestamp de processamento (modelo semanal).

Sem esse modelo, a lógica teria que ficar toda dentro do `int_prontuario_vitacare__paciente`, deixando o modelo diário mais pesado e menos auditável.

<img width="1448" height="1001" alt="Fluxo de enriquecimento de CPF(1)" src="https://github.com/user-attachments/assets/52d2cd85-f734-4f00-9a01-004fb0e35077" />
